### PR TITLE
chore: configure dependency updates and bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug report
+description: Report an error or incorrect financial result.
+body:
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How to reproduce
+      description: Include the command or a small code example, ticker, dates and relevant inputs. Remove credentials and private data.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: For numerical results, include the expected value and how you calculated it.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the complete traceback or incorrect output.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your operating system, Python release, installation command and relevant installed packages. Include the commit if known.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      python-dependencies:
+        update-types: [minor, patch]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Configure weekly dependency checks for the Python package and GitHub Actions, with grouped routine updates and Conventional Commit titles.

Add a concise bug-report form requesting reproduction steps, expected and actual results, and environment details. Reports about numerical results request the expected value and its calculation.

Validation: both YAML files parsed and their required fields checked; Ruff and whitespace checks pass.
