### PR TITLE
feat: expand public market research and strategy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - if: matrix.extras == 'core'
         run: python -m pip install . pytest
       - if: matrix.extras == 'full'
-        run: python -m pip install '.[data,portfolio,models,sentiment,plot,dev]'
+        run: python -m pip install '.[data,portfolio,models,sentiment,plot,reports,dev]'
       - run: python -m pytest
       - if: matrix.extras == 'full'
         run: |
@@ -36,3 +36,19 @@ jobs:
           python scripts/check_examples.py
         env:
           MPLBACKEND: Agg
+
+  optional:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - run: python -m pip install '.[models,neural,prophet,apps,reports,sentiment,dev]'
+      - run: python -m pytest tests/test_research_models_reports.py tests/test_app.py
+        env:
+          MPLBACKEND: Agg
+          OMP_NUM_THREADS: '1'
+          MKL_NUM_THREADS: '1'

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ python -m pip install -e .
 Core dependencies are NumPy and pandas. Add only the features you need:
 
 ```bash
-python -m pip install -e '.[data]'             # Yahoo Finance and constituent tables
+python -m pip install -e '.[data]'             # Public data, Finviz and financial statements
 python -m pip install -e '.[portfolio,models]' # Optimization and statistical/ML experiments
 python -m pip install -e '.[plot,sentiment]'   # Charts and VADER text scoring
+python -m pip install -e '.[apps,reports]'     # Interactive app and Excel exports
 ```
 
 ## Use
@@ -63,29 +64,35 @@ costs. Read the [calculation and execution conventions](docs/methodology.md) bef
 
 | Area | Capabilities |
 | --- | --- |
-| `data` | OHLCV/intraday, dividends, earnings, company snapshots, news, insiders, universes, CFTC positioning |
+| `data` | OHLCV/intraday, Finviz discovery, statements, calendars, analysts, news, transcripts, insiders and universes |
 | `indicators` | Moving averages, momentum, volatility/channels, volume, rolling statistics, pivots and breadth |
-| `analytics` | Returns, performance, CAPM/OLS, VaR, Kelly, valuation, seasonality and optional text sentiment |
-| `screening` | Relative strength, Minervini diagnostics, RSI, growth/value and dividend screens |
-| `strategies` | Crossovers, trend, mean reversion, breakouts, close-based stops and pairs experiments |
-| `backtesting` | Shared next-open execution, fill journal, equity/cash accounting and benchmark metrics |
+| `analytics` | Returns, CAPM/OLS, risk, statement ratios, company/index valuation, seasonal studies and sentiment |
+| `screening` | Relative strength, Minervini, Green Line, RSI/trend, growth/ownership and dividend screens |
+| `strategies` | Crossovers, MACD, Keltner, Ichimoku, oscillator reversion, pairs and chronological strategy selection |
+| `backtesting` | Next-open execution, long/short protective orders, FIFO trade reports, cash accounting and benchmarks |
 | `portfolio` | Allocation, constrained optimization/frontier, correlated simulation and lump sum versus DCA |
-| `models` | Chronological baseline evaluations, ARIMA, PCA, clustering, cointegration and anomalies |
+| `models` | Forecasts/baselines, ARIMA diagnostics, PCA/factors, regimes, clustering, networks and optional neural/Prophet experiments |
+| `reports` | Candlesticks, heatmaps, equity charts, CSV/Excel, HTML reports and graph exports |
+| `integrations` | Explicit notification transports, order previews and an optional Alpaca client |
 
-[Examples](examples) use seeded synthetic bars by default. Add `--live` for Yahoo data;
+[Examples](examples) use synthetic inputs by default. Add `--live` for public data;
 `download_market_data.py` always uses the network.
 
 ```bash
 python examples/calculate_indicators.py
 python examples/backtest_moving_average.py --live
 python examples/optimize_portfolio.py
-python examples/forecast_time_series.py
+python examples/research_watchlist.py --live
+python examples/research_models.py
+streamlit run apps/research.py
 ```
 
 Current constituents and fundamentals are snapshots, not historical point-in-time inputs.
 Public providers can throttle or change schemas; see [provider contracts](docs/providers.md).
 Forecast experiments report held-out errors against simple baselines and make no claim of
-predictive advantage. No brokerage execution or notification service is included.
+predictive advantage. Heavy models and apps are optional; brokerage and delivery require
+separate credentials. See [research workflows](docs/workflows.md) for full examples,
+optional installs and provider limitations.
 
 [Contributing](CONTRIBUTING.md)
 

--- a/apps/research.py
+++ b/apps/research.py
@@ -1,0 +1,129 @@
+"""Run with: streamlit run apps/research.py"""
+
+import pandas as pd
+import streamlit as st
+
+from finance.analytics import company_cash_flows, company_scenarios, sentiment
+from finance.backtesting import backtest, completed_trades, trade_statistics
+from finance.data import Finviz, ProviderError, YahooFinance, fetch_many
+from finance.indicators import bollinger_bands, cci, ema, macd, obv, rsi, sma
+from finance.portfolio import optimize
+from finance.reports import candles, equity_chart
+from finance.screening import growth_screen
+from finance.strategies import moving_average
+
+
+def main():
+    st.set_page_config(page_title="Finance research", layout="wide")
+    st.title("Finance research")
+    area = st.sidebar.selectbox(
+        "Research",
+        ["Stock & strategy", "Discover stocks", "Company valuation", "News", "Portfolio"],
+    )
+    ticker = st.sidebar.text_input("Ticker", "AAPL").strip().upper()
+    if area == "Stock & strategy":
+        with st.form("stock"):
+            start = st.date_input("Start", pd.Timestamp("2023-01-01"))
+            end = st.date_input("End (exclusive)", pd.Timestamp.today())
+            overlays = st.multiselect(
+                "Indicators",
+                ["SMA", "EMA", "Bollinger", "MACD", "RSI", "CCI", "OBV"],
+                default=["SMA", "Bollinger"],
+            )
+            fast = st.number_input("Fast average", min_value=2, value=20)
+            slow = st.number_input("Slow average", min_value=3, value=50)
+            submitted = st.form_submit_button("Analyze")
+        if submitted:
+            prices = YahooFinance().history(ticker, str(start), str(end))
+            lines = pd.DataFrame(index=prices.index)
+            if "SMA" in overlays:
+                lines["SMA"] = sma(prices.close)
+            if "EMA" in overlays:
+                lines["EMA"] = ema(prices.close)
+            if "Bollinger" in overlays:
+                lines = lines.join(bollinger_bands(prices.close).add_prefix("BB "))
+            st.pyplot(candles(prices.tail(120), lines.tail(120)))
+            for name in overlays:
+                if name == "MACD":
+                    st.line_chart(macd(prices.close))
+                elif name == "RSI":
+                    st.line_chart(rsi(prices.close))
+                elif name == "CCI":
+                    st.line_chart(cci(prices.high, prices.low, prices.close))
+                elif name == "OBV":
+                    st.line_chart(obv(prices.close, prices.volume))
+            result = backtest(
+                prices.open, prices.close, moving_average(prices.close, fast, slow), liquidate=True
+            )
+            st.pyplot(equity_chart(result))
+            st.dataframe(result.metrics.to_frame("value"))
+            trades = completed_trades(result.trades)
+            st.dataframe(trade_statistics(trades).to_frame("value"))
+            st.dataframe(trades)
+    elif area == "Discover stocks":
+        if st.button("Screen 20 large growth companies"):
+            f = Finviz()
+            discovery = f.screen(["cap_largeover", "fa_epsqoq_o10"], limit=20)
+            st.caption(
+                f"First 20 of {discovery.attrs['total_matches']} matches; current snapshots."
+            )
+            batch = fetch_many(discovery.index, f.company)
+            if not batch.errors.empty:
+                st.warning(batch.errors.to_string())
+            if batch.data:
+                st.dataframe(growth_screen(batch.table()))
+    elif area == "Company valuation":
+        growth = st.slider("Annual FCFF growth", -0.1, 0.3, 0.05)
+        discount = st.slider("Discount rate", 0.04, 0.2, 0.1)
+        terminal = st.slider("Terminal growth", 0.0, 0.05, 0.025)
+        if st.button("Value company"):
+            provider = YahooFinance()
+            flows = company_cash_flows(
+                provider.statements(ticker, "income"), provider.statements(ticker, "cashflow")
+            )
+            info = provider.company(ticker)
+            st.caption(
+                "FCFF uses after-tax operating income, depreciation, capex and working capital. Review inputs and dilution."
+            )
+            st.dataframe(flows)
+            st.dataframe(
+                company_scenarios(
+                    flows.fcff.iloc[-1],
+                    {"assumptions": [growth] * 5},
+                    discount,
+                    terminal_growth=terminal,
+                    cash=info.cash,
+                    debt=info.debt,
+                    shares=info.shares,
+                    price=info.price,
+                )
+            )
+    elif area == "News":
+        if st.button("Read headlines"):
+            news = Finviz().news(ticker)
+            st.dataframe(news)
+            scores = sentiment(news.title.tolist())
+            st.dataframe(scores[["text", "compound"]])
+            st.caption("Language sentiment describes headlines; it does not forecast returns.")
+    else:
+        symbols = st.text_input("Portfolio tickers", "AAPL MSFT JPM SPY").split()
+        if st.button("Find minimum variance allocation"):
+            provider = YahooFinance()
+            close = pd.DataFrame(
+                {
+                    s: provider.history(s, "2023-01-01", str(pd.Timestamp.today().date())).close
+                    for s in symbols
+                }
+            ).dropna()
+            changes = close.pct_change(fill_method=None).dropna()
+            result = optimize(changes.mean() * 252, changes.cov() * 252)
+            st.dataframe(result.weights.to_frame("weight"))
+            st.dataframe(close.pct_change(fill_method=None).corr())
+            st.caption("Historical estimates; allocation is sensitive to the selected sample.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ProviderError, ValueError) as exc:
+        st.error(str(exc))

--- a/apps/research.py
+++ b/apps/research.py
@@ -41,7 +41,9 @@ def main():
             if "EMA" in overlays:
                 lines["EMA"] = ema(prices.close)
             if "Bollinger" in overlays:
-                lines = lines.join(bollinger_bands(prices.close).add_prefix("BB "))
+                lines = lines.join(
+                    bollinger_bands(prices.close)[["lower", "middle", "upper"]].add_prefix("BB ")
+                )
             st.pyplot(candles(prices.tail(120), lines.tail(120)))
             for name in overlays:
                 if name == "MACD":

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -46,14 +46,20 @@ The engine solves for post-transaction equity before sizing orders, including co
 and directional slippage. Short proceeds are credited to cash and the liability is marked
 at each close. Annual borrow charges accrue per held bar using opening short notional.
 Cash earns zero interest; the engine raises on insolvency. This is a research engine without
-margin loans, intrabar order sequencing, dividends as separate cash flows, market impact,
+margin loans, tick-level order sequencing, dividends as separate cash flows, market impact,
 liquidity constraints or a borrow-availability model. Short simulations therefore need
 additional execution assumptions before any real-world interpretation.
 
 The optional final close liquidation is precommitted, independent of that day's signal.
 Trade rows are fills, including reversals and partial rebalances, not inferred round trips.
 The benchmark is a cost-free equal-dollar buy-and-hold basket bought at the first open.
-Close-based trailing stops execute at the next open, which may gap past the threshold.
+Close-based signal stops execute at the next open, which may gap past the threshold.
+Optional engine protective orders require high/low inputs. Gap fills use the opening price;
+when both thresholds occur within a bar, stops take priority unless the open already crosses
+the profit threshold. Trailing levels use extrema from completed bars. Stops are anchored at
+the initial fill of a position, including through partial rebalances. Rearming requires a
+source-target change. Borrow is charged for the opening short exposure even if stopped that bar.
+FIFO completed-lot reports allocate commissions by quantity; borrow stays at account level.
 
 Performance uses compounded simple returns and includes initial capital in the drawdown
 peak. Volatility is annualized sample deviation; Sharpe subtracts an annual risk-free rate
@@ -80,7 +86,10 @@ forecast year; discount rate must exceed terminal growth. Unlevered enterprise c
 are discounted at WACC, then cash is added and debt subtracted. Per-share dividends can use
 the same formula with equity discount rate and zero debt/cash adjustments. Do not treat
 Yahoo's reported free cash flow as automatically unlevered cash flow. Scenario examples
-state assumptions; their values are not investment recommendations.
+state assumptions; their values are not investment recommendations. The statement workflow
+estimates operating-company FCFF as after-tax operating income plus depreciation, signed capex
+and working-capital cash changes. Stock compensation is not added back. This approximation
+is inappropriate for banks. Annual scenario growth requires annual base cash flow.
 
 ## Models and provider dates
 
@@ -113,5 +122,5 @@ dates similarly do not establish when a filing became available.
 Tests also use hand-computed fixtures, the two-asset inverse-variance/tangency solutions,
 OLS equations, a perpetuity identity, independently reconstructed fills and analytical GBM
 moments. Prefix-invariance tests check that future data does not change prior indicators,
-signals or equity. Provider contract tests use mocked responses; `pytest --live -m integration`
+signals or equity, including protective orders. Provider contract tests use mocked responses; `pytest --live -m integration`
 checks real data and financial workflows.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Data providers
 
-Install `.[data]` for Yahoo Finance and S&P500 HTML parsing. Pure calculations need no data
+Install `.[data]` for Yahoo Finance, Finviz and HTML parsing. Pure calculations need no data
 extra. `YahooFinance.history(ticker, start, end, interval='1d')` returns one normalized OHLCV
 frame with a date index, lowercase columns, positive prices and nonnegative volume. End is
 exclusive. Intraday history has provider retention limits. `adjusted=True` is explicit;
@@ -36,5 +36,26 @@ Ordinary tests mock transport and never require network access. After installing
 `.[data,portfolio,models,dev]`, run `python -m pytest --live -m integration` to check provider
 schemas and financial workflows against real data. Daily checks use a fixed historical
 period; intraday checks use the last two weeks. Use `python scripts/check_examples.py --live`
-to run examples with Yahoo data (install the extras listed in the README). Live checks are
+to run examples with public data (install the extras listed in the README). Live checks are
 opt-in and excluded from CI; provider failures are reported as test failures.
+
+
+Finviz provides public screener, company, analyst, insider and news snapshots. Fetching uses
+bounded retries for throttling/transient server errors, per-client request spacing and a
+short in-memory cache. Pagination rejects duplicate rows and changing result counts;
+explicit limits are reported through `complete` and `total_matches` attributes. An HTTP 200
+response without the expected table is an error, not an empty result. Percentages normalize
+to fractions; multiple measures inside a cell remain distinct. Native ticker symbols are
+preserved. Homepage macro/futures/FX values retain their source strings and units.
+
+Yahoo statement rows identify reporting-period ends, not filing availability; historical
+statements may be restated. Statement currency and retrieval time are recorded. Analyst
+rating/target changes retain vendor text because scales differ between research firms.
+News `source_time` retains the displayed time; it must not be treated as a normalized UTC
+publication timestamp. RSS feeds provide parsed UTC dates when supplied by the publisher.
+
+TradingView's public scanner was verified for current recommendations, but it is undocumented
+and may change or become inaccessible. Intraday OHLCV comes from Yahoo, with Yahoo's retention
+limits. Public Motley Fool transcripts were verified by article URL. Reddit anonymous access
+returned HTTP 403; its adapter reports that failure. Anonymous X collection and authenticated
+brokerage/delivery have not been verified. See [workflows](workflows.md) for supported entry points.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,171 @@
+# Research workflows
+
+Examples use synthetic inputs unless `--live` is supplied. Public data needs `.[data]`;
+model, chart and sentiment examples need their respective extras. No account is needed
+for the public workflows below.
+
+## Discover and research companies
+
+```bash
+python examples/research_watchlist.py --live --output ./research
+python examples/research_company.py --live
+```
+
+The watchlist example downloads the first 20 large-company matches with quarterly EPS
+growth above 10%, enriches them, and explains the growth, margin, ownership and P/E checks.
+The HTML and CSV reports include all examined candidates, including failures of the screen.
+This is a bounded sample, not a complete market scan.
+
+```python
+from finance.data import Finviz, fetch_many
+from finance.screening import growth_screen
+
+provider = Finviz()
+universe = provider.screen(['cap_largeover', 'fa_epsqoq_o10'], limit=100)
+batch = fetch_many(universe.index, provider.company)
+print(batch.errors)  # Failed tickers remain visible.
+result = growth_screen(batch.table())
+```
+
+Finviz filters use the codes in its public screener URLs. `screen` reports `total_matches`
+and `complete` in DataFrame attributes. `universe('dow')` and `universe('russell2000')`
+use Finviz's current index classifications; they are not licensed historical constituent
+records. `snapshot_changes(before, after)` compares snapshots you have actually collected.
+It cannot reconstruct earlier membership or recommendations.
+
+`YahooFinance.statements(ticker, kind, frequency)` accepts `income`, `balance`, `cashflow`
+and `annual`/`quarterly`. Rows are reporting periods; fields retain provider statement names.
+`statement_ratios` calculates margins, average-equity ROE, leverage and current ratios.
+`company_cash_flows` estimates operating-company FCFF from after-tax operating income,
+depreciation, signed capex and working-capital cash changes. Missing latest-period inputs
+raise an error. Review source currency, fiscal dates and assumptions before valuation.
+
+`company_scenarios` accepts explicit annual growth paths, discount rate, cash, debt and
+shares. `index_scenarios` values index dividends from EPS, payout and recovery paths; the
+example's index inputs are illustrative, not scraped estimates.
+
+## Signals and strategy evaluation
+
+```bash
+python examples/research_strategies.py --live
+```
+
+This compares moving-average, MACD, Keltner, stochastic, Williams %R and Ichimoku signals
+with several stop thresholds on a training period. Only the selected configuration runs
+on the later holdout. Each signal family is also callable independently.
+
+```python
+from finance.backtesting import backtest, completed_trades, trade_statistics
+from finance.strategies import macd_trend
+
+result = backtest(
+    prices.open, prices.close, macd_trend(prices.close, short=True),
+    high_prices=prices.high, low_prices=prices.low,
+    stop_loss=.08, take_profit=.20, trailing_fraction=.10,
+    commission=.001, liquidate=True,
+)
+print(trade_statistics(completed_trades(result.trades)))
+```
+
+Protective orders use observed high/low ranges. Gaps execute at the open; ambiguous
+same-bar stop/profit hits use the stop first. Trailing levels update after the bar.
+A stopped position waits for the source target to change before rearming. These assumptions
+cannot recover an intrabar price path from daily bars.
+
+`completed_trades` matches FIFO lot portions and apportions commissions. Its statistics
+count matched lots; borrow costs remain an account-level expense. Partial closes can produce
+multiple rows for one position. Open lots are not treated as completed trades.
+
+`green_line_screen` builds a proximity watchlist using completed months. `rsi_trend_screen`
+combines price above its SMA with a two-observation RSI average. `seasonal_entries` reports
+actual entry/exit dates and forward returns; `seasonal_summary` compares a supplied universe.
+Selecting seasonal dates after looking at their results is in-sample research.
+
+## Models and distributions
+
+```bash
+python examples/research_models.py --live
+python -m pip install -e '.[neural,prophet]'
+python examples/research_models.py --live --neural --prophet
+```
+
+`forecast_latest` fits known labels and predicts from the latest close. Evaluate the chosen
+model with `evaluate_forecast` before interpreting that output. `select_arima_order` uses
+training BIC; `arima_forecast` returns future observation steps and model-based intervals.
+Future step numbers deliberately make no assumption about exchange holidays.
+
+`arima_diagnostics` provides stationarity/residual checks and retrospective decomposition.
+`factor_analysis` reports loadings, communalities, KMO and Bartlett diagnostics.
+`volatility_regimes` fits a mixture on earlier rolling volatility and returns later state
+probabilities. `student_t_fit` estimates degrees of freedom, location, scale and quantiles.
+`partial_correlations_cv` selects regularization for a descriptive dependence network.
+
+LSTM/CNN experiments predict next-observation returns using earlier windows. Prophet uses
+a fixed-origin log-price forecast. All report held-out errors against simple baselines.
+Changing architectures or parameters repeatedly after inspecting those errors turns the
+holdout into tuning data; reserve another period for a final assessment.
+
+## News, calendars and external signals
+
+```bash
+python examples/research_news.py --live
+```
+
+`Finviz.news()` discovers market-wide headlines; pass a ticker for company headlines.
+`Finviz.insiders()` retrieves recent market-wide insider activity, and `analysts(ticker)`
+returns dated rating/target changes. `market()` exposes movers, today's macro calendar,
+futures and FX/bond summaries. `earnings_calendar(start, end)` uses Nasdaq for up to 31 days.
+
+`rss_news(url)` reads public RSS feeds. `transcript_index()` discovers recent Motley Fool
+transcripts; `article_text(url)` retrieves accessible article text. `sentence_sentiment`
+keeps the sentence evidence behind language scores. Do not interpret those scores as
+measures of investment quality or expected returns.
+
+`TradingView().recommendations(['NASDAQ:AAPL'], interval='1d')` retrieves public scanner
+recommendations. This is an undocumented snapshot endpoint, not a licensed historical feed.
+Use `YahooFinance.history(..., interval='5m')` for intraday bars within provider retention.
+
+`reddit_posts` attempts public recent-post retrieval and fails explicitly if access is
+blocked. Reddit rejected anonymous requests during verification. `social_mentions` can
+analyze supplied post tables (`id`, `text`) against an explicit ticker universe. Anonymous
+X search/timeline collection is not provided; access has not been established reliably.
+
+## Charts, reports and the app
+
+```bash
+python -m pip install -e '.[apps,reports,sentiment]'
+streamlit run apps/research.py
+```
+
+The app covers stock charts, indicator overlays, strategy results, company discovery,
+valuation, headlines and portfolio allocation. Indicators and calculations use the same
+Python functions as the examples. Data is fetched when an analysis is submitted.
+
+`candles`, `equity_chart` and `correlation_heatmap` return matplotlib figures.
+`export_table` writes CSV or Excel; `research_report` writes standalone HTML tables.
+`network_gexf` exports signed dependence edges for Gephi. `gann_fan` requires explicit
+price-per-bar units, and `speed_resistance` exposes lines only once a supplied swing has
+completed. These are drawing conventions, not evidence of predictive value.
+
+## Optional delivery and brokerage
+
+```bash
+python examples/preview_order.py
+```
+
+This only constructs an order, illustrates partial-fill reconciliation and previews an
+email. Nothing is submitted or sent. `email_report` creates a message; `send_email`,
+`send_sms` and `send_webhook` perform explicit deliveries using your credentials/destination.
+For scheduled reports, invoke the watchlist example from your existing OS scheduler and
+send its output through the chosen transport. The library does not install background jobs.
+
+`Alpaca` exposes account, positions, recent orders, client-ID lookup, limit-order submission
+and cancellation. It defaults to Alpaca's paper endpoint. Supply credentials explicitly;
+never put them in source files. Live submission additionally requires `allow_live=True`.
+`reconcile_orders` distinguishes partial fills and unknown orders. After a submission timeout,
+look up the original client ID before deciding whether to retry; unknown does not mean rejected.
+
+Brokerage and delivery transports have offline contract checks. Account-connected execution
+and actual delivery have not been verified because no credentials were supplied. There is
+no Robinhood equity client or unattended live-trading bot. Alpaca account access is required
+for connected stock execution; scraping cannot replace brokerage authentication.

--- a/examples/preview_order.py
+++ b/examples/preview_order.py
@@ -1,0 +1,28 @@
+"""Build an order and email preview locally. This example never submits or sends."""
+
+from finance.integrations import email_report, preview_order, reconcile_orders
+
+
+def main():
+    order = preview_order(
+        "AAPL", 2, "buy", 200, maximum_notional=500, client_order_id="example-aapl-001"
+    )
+    print(order)
+    print(
+        reconcile_orders(
+            [order],
+            [
+                {
+                    "client_order_id": order.client_order_id,
+                    "status": "partially_filled",
+                    "filled_qty": "1",
+                    "filled_avg_price": "199.5",
+                }
+            ],
+        )
+    )
+    print(email_report("research@example.com", "reader@example.com", "Order preview", str(order)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/research_company.py
+++ b/examples/research_company.py
@@ -1,0 +1,70 @@
+"""Estimate company value from statements and explicit growth scenarios. Add --live for AAPL."""
+
+import sys
+
+import pandas as pd
+
+from finance.analytics import (
+    company_cash_flows,
+    company_scenarios,
+    index_scenarios,
+    statement_ratios,
+)
+from finance.data import YahooFinance
+
+
+def main():
+    if "--live" in sys.argv:
+        provider = YahooFinance()
+        income = provider.statements("AAPL", "income")
+        cashflow = provider.statements("AAPL", "cashflow")
+        print(statement_ratios(income, provider.statements("AAPL", "balance")).round(3))
+        company = provider.company("AAPL")
+        cash, debt, shares, price = (company[key] for key in ["cash", "debt", "shares", "price"])
+    else:
+        print("Synthetic financial statements; amounts in USD.")
+        index = pd.to_datetime(["2023-12-31", "2024-12-31"])
+        income = pd.DataFrame(
+            {
+                "Operating Income": [110e6, 132e6],
+                "Tax Provision": [20e6, 24e6],
+                "Pretax Income": [100e6, 120e6],
+            },
+            index=index,
+        )
+        cashflow = pd.DataFrame(
+            {
+                "Depreciation And Amortization": [10e6, 12e6],
+                "Capital Expenditure": [-20e6, -25e6],
+                "Change In Working Capital": [-5e6, -6e6],
+            },
+            index=index,
+        )
+        cash, debt, shares, price = 50e6, 100e6, 10e6, 100
+    flows = company_cash_flows(income, cashflow)
+    print("FCFF approximation by reported period:\n", flows.to_string())
+    scenarios = {
+        "slow": [0.02] * 5,
+        "base": [0.08, 0.07, 0.06, 0.05, 0.04],
+        "fast": [0.15, 0.12, 0.1, 0.08, 0.06],
+    }
+    print(
+        company_scenarios(
+            flows.fcff.iloc[-1], scenarios, 0.10, cash=cash, debt=debt, shares=shares, price=price
+        )
+        .round(2)
+        .to_string()
+    )
+    print("Illustrative index EPS/payout assumptions:")
+    print(
+        index_scenarios(
+            250,
+            {"recovery": [-0.15, 0.2, 0.1, 0.05, 0.04], "slow": [0, 0.02, 0.03, 0.03, 0.03]},
+            payout=0.4,
+            discount_rate=0.09,
+        ).round(2)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/research_models.py
+++ b/examples/research_models.py
@@ -1,0 +1,46 @@
+"""Forecast, diagnose and compare statistical experiments; --neural/--prophet need extras."""
+
+import sys
+
+from _data import load_prices
+
+from finance.models import (
+    arima_diagnostics,
+    arima_forecast,
+    evaluate_forecast,
+    evaluate_prophet,
+    evaluate_sequence,
+    factor_analysis,
+    forecast_latest,
+    partial_correlations_cv,
+    select_arima_order,
+    student_t_fit,
+    volatility_regimes,
+)
+
+
+def main():
+    import pandas as pd
+
+    prices = load_prices(("AAPL", "MSFT", "JPM", "SPY"))
+    closes = pd.DataFrame({ticker: p.close for ticker, p in prices.items()})
+    changes = closes.pct_change(fill_method=None).dropna()
+    print(evaluate_forecast(closes.AAPL).metrics)
+    print(forecast_latest(closes.AAPL).to_string())
+    orders = select_arima_order(closes.AAPL)
+    print(orders)
+    print(arima_forecast(closes.AAPL, order=orders.order.iloc[0]))
+    print(arima_diagnostics(closes.AAPL)[0])
+    print(student_t_fit(changes.AAPL))
+    print(factor_analysis(changes, 2).diagnostics)
+    print(partial_correlations_cv(changes).round(3))
+    print(volatility_regimes(closes.AAPL).tail())
+    if "--neural" in sys.argv:
+        for architecture in ["lstm", "cnn"]:
+            print(evaluate_sequence(closes.AAPL, architecture=architecture).metrics)
+    if "--prophet" in sys.argv:
+        print(evaluate_prophet(closes.AAPL).metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/research_news.py
+++ b/examples/research_news.py
@@ -1,0 +1,34 @@
+"""Headline and transcript language analysis. Add --live for public sources."""
+
+import sys
+
+from finance.analytics import sentence_sentiment, sentiment
+from finance.data import Finviz, TradingView, article_text, transcript_index
+
+
+def main():
+    if "--live" in sys.argv:
+        provider = Finviz()
+        news = provider.news("AAPL")
+        print(news[["title", "url"]].head(5).to_string(index=False))
+        print(sentiment(news.title.head(20).tolist())[["compound"]].describe())
+        print(TradingView().recommendations(["NASDAQ:AAPL", "NASDAQ:MSFT"]))
+        transcripts = transcript_index()
+        print("Transcript source:", transcripts.url.iloc[0])
+        text = article_text(transcripts.url.iloc[0])
+    else:
+        text = "Revenue increased strongly. We face significant uncertainty and weaker demand. Cash flow remained stable."
+    scores = sentence_sentiment(text)
+    print(
+        "Sentence counts:",
+        len(scores),
+        "Positive:",
+        (scores.compound >= 0.05).sum(),
+        "Negative:",
+        (scores.compound <= -0.05).sum(),
+    )
+    print("Mean descriptive sentiment:", round(scores.compound.mean(), 3))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/research_strategies.py
+++ b/examples/research_strategies.py
@@ -1,0 +1,57 @@
+"""Compare signal families on a chronological holdout and inspect stop-aware trades."""
+
+from _data import load_prices
+
+from finance.analytics import seasonal_summary
+from finance.backtesting import backtest, completed_trades, trade_statistics
+from finance.screening import green_line_screen, rsi_trend_screen
+from finance.strategies import (
+    ichimoku_trend,
+    keltner_breakout,
+    macd_trend,
+    moving_average,
+    select_strategy,
+    stochastic_reversion,
+    williams_reversion,
+)
+
+
+def main():
+    prices = load_prices()["AAPL"]
+    candidates = {
+        "ma": lambda p: moving_average(p.close),
+        "macd": lambda p: macd_trend(p.close),
+        "keltner": lambda p: keltner_breakout(p.high, p.low, p.close),
+        "stochastic": lambda p: stochastic_reversion(p.high, p.low, p.close),
+        "williams": lambda p: williams_reversion(p.high, p.low, p.close),
+        "ichimoku": lambda p: ichimoku_trend(p.high, p.low, p.close),
+    }
+    selection = select_strategy(prices, candidates, stop_losses=(None, 0.05, 0.1))
+    print(
+        "Training scores:",
+        selection.training_scores[["candidate", "stop_loss", "total_return", "max_drawdown"]].round(
+            3
+        ),
+    )
+    print(
+        "Selected:", selection.selected, "Holdout:", selection.holdout.metrics.round(3).to_string()
+    )
+    result = backtest(
+        prices.open,
+        prices.close,
+        moving_average(prices.close, short=True),
+        high_prices=prices.high,
+        low_prices=prices.low,
+        stop_loss=0.08,
+        trailing_fraction=0.1,
+        take_profit=0.2,
+        liquidate=True,
+    )
+    print(trade_statistics(completed_trades(result.trades)).to_string())
+    print(green_line_screen({"AAPL": prices}).to_string())
+    print(rsi_trend_screen(prices[["close"]]).to_string())
+    print(seasonal_summary(prices[["close"]], 1, 15, 3).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/research_watchlist.py
+++ b/examples/research_watchlist.py
@@ -1,0 +1,52 @@
+"""Discover growth stocks, explain the screen and optionally export a report. Add --live for Finviz."""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from finance.data import Finviz, fetch_many
+from finance.reports import export_table, research_report
+from finance.screening import growth_screen
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.live:
+        provider = Finviz()
+        discovery = provider.screen(["cap_largeover", "fa_epsqoq_o10"], limit=20)
+        batch = fetch_many(discovery.index, provider.company)
+        if not batch.errors.empty:
+            print("Provider failures:", batch.errors.to_string())
+        if not batch.data:
+            raise RuntimeError("No company snapshots available")
+        companies = batch.table()
+        companies.attrs = discovery.attrs
+        print(f"Examining {len(companies)} of {discovery.attrs['total_matches']} matches")
+    else:
+        print("Synthetic company inputs; use --live for public Finviz snapshots.")
+        companies = pd.DataFrame(
+            {
+                "earnings_growth": [0.2, 0.04, 0.3],
+                "revenue_growth": [0.15, 0.1, 0.2],
+                "profit_margin": [0.2, 0.12, 0.15],
+                "institutional_transactions": [0.03, 0.01, -0.02],
+                "pe": [25, 30, 35],
+            },
+            index=["ALPHA", "BETA", "GAMMA"],
+        )
+    result = growth_screen(companies)
+    print(
+        result[["earnings_growth", "revenue_growth", "profit_margin", "pe", "passed"]].to_string()
+    )
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        export_table(result, args.output / "watchlist.csv")
+        research_report({"Growth screen": result}, args.output / "watchlist.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/select_strategy.py
+++ b/examples/select_strategy.py
@@ -1,28 +1,25 @@
-import pandas as pd
+from functools import partial
+
 from _data import load_prices
 
-from finance.backtesting import backtest
-from finance.strategies import moving_average
+from finance.strategies import moving_average, select_strategy
+
+
+def signal(prices, fast, slow):
+    return moving_average(prices.close, fast, slow)
 
 
 def main():
     prices = load_prices()["AAPL"]
-    split = int(len(prices) * 0.7)
-    candidates = [(10, 50), (20, 50), (20, 100), (50, 200)]
-    rows = []
-    for fast, slow in candidates:
-        signals = moving_average(prices.close.iloc[:split], fast, slow)
-        result = backtest(prices.open.iloc[:split], prices.close.iloc[:split], signals)
-        rows.append({"fast": fast, "slow": slow, "training_sharpe": result.metrics.sharpe})
-    ranking = pd.DataFrame(rows).sort_values("training_sharpe", ascending=False)
-    best = ranking.iloc[0]
-    signals = moving_average(prices.close, int(best.fast), int(best.slow))
-    # Include one flat origin bar to make its closing decision available at the first test open.
-    test = prices.iloc[split - 1 :]
-    result = backtest(test.open, test.close, signals.iloc[split - 1 :])
-    print(ranking.to_string(index=False))
-    print("Frozen-parameter chronological holdout:")
-    print(result.metrics.round(4).to_string())
+    candidates = {
+        f"SMA {fast}/{slow}": partial(signal, fast=fast, slow=slow)
+        for fast, slow in [(10, 50), (20, 50), (20, 100), (50, 200)]
+    }
+    selection = select_strategy(prices, candidates, metric="sharpe")
+    print(selection.training_scores[["candidate", "sharpe"]].to_string(index=False))
+    print("Selected:", selection.selected)
+    print("Chronological holdout:")
+    print(selection.holdout.metrics.round(4).to_string())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ data = ["yfinance>=0.2.65,<2", "lxml>=5,<7"]
 portfolio = ["scipy>=1.14,<2"]
 models = ["scikit-learn>=1.5,<2", "statsmodels>=0.14.4,<1"]
 sentiment = ["vaderSentiment>=3.3.2,<4"]
+neural = ["torch>=2.6,<3"]
+prophet = ["prophet>=1.1.6,<2"]
+apps = ["scipy>=1.14,<2", "streamlit>=1.45,<2", "matplotlib>=3.9,<4", "lxml>=5,<7", "yfinance>=0.2.65,<2"]
+reports = ["openpyxl>=3.1,<4", "matplotlib>=3.9,<4"]
 plot = ["matplotlib>=3.9,<4"]
 dev = ["pytest>=8,<10", "ruff>=0.11,<1", "build>=1.2,<2", "ta>=0.11,<1"]
 
@@ -34,7 +38,7 @@ markers = ["integration: explicit live provider checks (not part of offline CI)"
 [tool.ruff]
 target-version = "py312"
 line-length = 100
-include = ["src/**/*.py", "tests/**/*.py", "examples/**/*.py", "scripts/**/*.py", "pyproject.toml"]
+include = ["src/**/*.py", "tests/**/*.py", "examples/**/*.py", "scripts/**/*.py", "apps/**/*.py", "pyproject.toml"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP"]

--- a/src/finance/analytics/__init__.py
+++ b/src/finance/analytics/__init__.py
@@ -1,4 +1,12 @@
 from .regression import RegressionResult, capm, correlation_pairs, ols
+from .research import (
+    company_cash_flows,
+    company_scenarios,
+    index_scenarios,
+    seasonal_entries,
+    seasonal_summary,
+    statement_ratios,
+)
 from .returns import (
     cumulative_returns,
     distribution,
@@ -18,7 +26,7 @@ from .risk import (
     risk_reward,
     value_at_risk,
 )
-from .sentiment import sentiment
+from .sentiment import sentence_sentiment, sentiment, social_mentions
 from .valuation import Valuation, discounted_cash_flow, fundamental_ratios, scenario_valuation
 
 __all__ = [
@@ -46,4 +54,13 @@ __all__ = [
     "discounted_cash_flow",
     "scenario_valuation",
     "fundamental_ratios",
+    "seasonal_entries",
+    "seasonal_summary",
+    "company_cash_flows",
+    "company_scenarios",
+    "index_scenarios",
+    "sentence_sentiment",
+    "social_mentions",
 ]
+
+__all__ += ["statement_ratios"]

--- a/src/finance/analytics/research.py
+++ b/src/finance/analytics/research.py
@@ -1,0 +1,212 @@
+"""Calendar studies and explicit company/index valuation assumptions."""
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+
+from finance._validation import series
+from finance.analytics.valuation import discounted_cash_flow
+
+
+def seasonal_entries(
+    close: pd.Series, month: int, day: int, holding_months: int = 1
+) -> pd.DataFrame:
+    """First observed close on/after calendar dates; completed holds only. Descriptive, overlapping samples."""
+    close = series(close, positive=True, missing=False)
+    if not isinstance(close.index, pd.DatetimeIndex) or not close.index.is_monotonic_increasing:
+        raise ValueError("require chronologically indexed prices")
+    if not 1 <= holding_months <= 36:
+        raise ValueError("holding_months must be 1–36")
+    pd.Timestamp(2000, month, day)
+    rows = []
+    for year in close.index.year.unique():
+        try:
+            scheduled = pd.Timestamp(year, month, day, tz=close.index.tz)
+        except ValueError:
+            continue  # February 29 is absent in non-leap years.
+        if scheduled < close.index[0]:
+            continue
+        entry = close.index.searchsorted(scheduled)
+        if entry == len(close):
+            continue
+        due = close.index[entry] + pd.DateOffset(months=holding_months)
+        exit = close.index.searchsorted(due)
+        if exit == len(close):
+            continue
+        rows.append(
+            {
+                "year": year,
+                "entry": close.index[entry],
+                "exit": close.index[exit],
+                "entry_price": close.iloc[entry],
+                "exit_price": close.iloc[exit],
+                "return": close.iloc[exit] / close.iloc[entry] - 1,
+            }
+        )
+    return pd.DataFrame(
+        rows, columns=["year", "entry", "exit", "entry_price", "exit_price", "return"]
+    )
+
+
+def seasonal_summary(
+    prices: pd.DataFrame, month: int, day: int, holding_months: int = 1
+) -> pd.DataFrame:
+    rows = []
+    for ticker in prices:
+        study = seasonal_entries(prices[ticker], month, day, holding_months)
+        rows.append(
+            {
+                "ticker": ticker,
+                "observations": len(study),
+                "mean_return": study["return"].mean(),
+                "median_return": study["return"].median(),
+                "win_rate": (study["return"] > 0).mean() if len(study) else np.nan,
+            }
+        )
+    return pd.DataFrame(rows).set_index("ticker")
+
+
+def company_cash_flows(income: pd.DataFrame, cashflow: pd.DataFrame) -> pd.DataFrame:
+    """FCFF = operating income × (1-tax) + D&A + signed capex + cash change in working capital.
+
+    Uses reported cash-flow signs: capex is negative, a working-capital cash release positive.
+    Stock compensation is not added back. This operating-company approximation excludes banks.
+    """
+    required = ["Operating Income", "Tax Provision", "Pretax Income"]
+    cash_columns = [
+        "Depreciation And Amortization",
+        "Capital Expenditure",
+        "Change In Working Capital",
+    ]
+    if not set(required) <= set(income) or not set(cash_columns) <= set(cashflow):
+        raise ValueError(
+            "statements require operating income, tax, pretax income, D&A, capex and working capital"
+        )
+    left_currency, right_currency = income.attrs.get("currency"), cashflow.attrs.get("currency")
+    if left_currency and right_currency and left_currency != right_currency:
+        raise ValueError("statement currencies differ")
+    data = income[required].join(cashflow[cash_columns], how="inner").sort_index()
+    if data.empty or data.iloc[-1].isna().any():
+        raise ValueError(
+            "latest common statement period is incomplete; supply complete inputs explicitly"
+        )
+    data = data.dropna()
+    if not np.isfinite(data).all().all() or (data["Pretax Income"] <= 0).any():
+        raise ValueError("require complete periods with positive pretax income")
+    rate = data["Tax Provision"] / data["Pretax Income"]
+    if (
+        not rate.between(0, 1).all()
+        or (data["Capital Expenditure"] > 0).any()
+        or (data["Depreciation And Amortization"] < 0).any()
+    ):
+        raise ValueError("invalid tax rate, depreciation or capex sign")
+    result = pd.DataFrame(
+        {
+            "tax_rate": rate,
+            "after_tax_operating_income": data["Operating Income"] * (1 - rate),
+            "depreciation": data["Depreciation And Amortization"],
+            "capex": data["Capital Expenditure"],
+            "working_capital_cash_change": data["Change In Working Capital"],
+        }
+    )
+    result["fcff"] = result.drop(columns="tax_rate").sum(axis=1)
+    result.attrs.update(currency=left_currency, frequency=income.attrs.get("frequency"))
+    return result
+
+
+def company_scenarios(
+    base_fcff: float,
+    growth_paths: dict[str, Sequence[float]],
+    discount_rate: float,
+    *,
+    terminal_growth: float = 0.025,
+    cash: float = 0,
+    debt: float = 0,
+    shares: float = 1,
+    price: float | None = None,
+) -> pd.DataFrame:
+    if not np.isfinite(base_fcff) or base_fcff <= 0 or not growth_paths:
+        raise ValueError("positive base FCFF and growth scenarios required")
+    if price is not None and (not np.isfinite(price) or price <= 0):
+        raise ValueError("price must be positive")
+    rows = []
+    for name, growth in growth_paths.items():
+        growth = np.asarray(growth, dtype=float)
+        if (
+            growth.ndim != 1
+            or not len(growth)
+            or not np.isfinite(growth).all()
+            or (growth <= -1).any()
+        ):
+            raise ValueError("growth paths must be nonempty, finite and above -1")
+        value = discounted_cash_flow(
+            base_fcff * np.cumprod(1 + growth),
+            discount_rate,
+            terminal_growth,
+            cash=cash,
+            debt=debt,
+            shares=shares,
+        )
+        rows.append(
+            {
+                "scenario": name,
+                "enterprise_value": value.enterprise_value,
+                "equity_value": value.equity_value,
+                "value_per_share": value.value_per_share,
+                "upside": value.value_per_share / price - 1 if price else np.nan,
+            }
+        )
+    return pd.DataFrame(rows).set_index("scenario")
+
+
+def index_scenarios(
+    earnings: float,
+    growth_paths: dict[str, Sequence[float]],
+    *,
+    payout: float,
+    discount_rate: float,
+    terminal_growth: float = 0.025,
+) -> pd.DataFrame:
+    """Dividend-discount scenarios from index EPS and an explicit payout fraction."""
+    if not np.isfinite(earnings) or earnings <= 0 or not 0 < payout <= 1:
+        raise ValueError("positive index EPS and payout in (0,1] required")
+    result = company_scenarios(
+        earnings * payout, growth_paths, discount_rate, terminal_growth=terminal_growth
+    )
+    return result[["value_per_share"]].rename(columns={"value_per_share": "index_value"})
+
+
+def statement_ratios(income: pd.DataFrame, balance: pd.DataFrame) -> pd.DataFrame:
+    """Period-aligned margins and balance ratios. ROE uses average beginning/end equity."""
+    required_income = ["Total Revenue", "Gross Profit", "Operating Income", "Net Income"]
+    required_balance = [
+        "Total Assets",
+        "Stockholders Equity",
+        "Total Debt",
+        "Current Assets",
+        "Current Liabilities",
+    ]
+    if not set(required_income) <= set(income) or not set(required_balance) <= set(balance):
+        raise ValueError("missing required income/balance statement fields")
+    left, right = income.attrs.get("currency"), balance.attrs.get("currency")
+    if left and right and left != right:
+        raise ValueError("statement currencies differ")
+    data = income[required_income].join(balance[required_balance], how="inner").sort_index()
+    if data.empty:
+        raise ValueError("no common reporting periods")
+    revenue = data["Total Revenue"].where(data["Total Revenue"] > 0)
+    equity = data["Stockholders Equity"].where(data["Stockholders Equity"] > 0)
+    average_equity = (equity + equity.shift()) / 2
+    return pd.DataFrame(
+        {
+            "gross_margin": data["Gross Profit"] / revenue,
+            "operating_margin": data["Operating Income"] / revenue,
+            "net_margin": data["Net Income"] / revenue,
+            "roe": data["Net Income"] / average_equity,
+            "debt_equity": data["Total Debt"] / equity,
+            "current_ratio": data["Current Assets"]
+            / data["Current Liabilities"].where(data["Current Liabilities"] > 0),
+            "revenue_growth": revenue.pct_change(fill_method=None),
+        }
+    )

--- a/src/finance/analytics/sentiment.py
+++ b/src/finance/analytics/sentiment.py
@@ -11,3 +11,33 @@ def sentiment(texts: Sequence[str]) -> pd.DataFrame:
         raise ValueError("provide a nonempty sequence of texts")
     analyzer = SentimentIntensityAnalyzer()
     return pd.DataFrame([{"text": text, **analyzer.polarity_scores(text)} for text in texts])
+
+
+def sentence_sentiment(text: str) -> pd.DataFrame:
+    """Sentence-level evidence for transcript/article language scores."""
+    import re
+
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("provide nonempty article text")
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+|\n\s*\n", text) if s.strip()]
+    return sentiment(sentences).assign(sentence=range(1, len(sentences) + 1))
+
+
+def social_mentions(posts: pd.DataFrame, tickers: Sequence[str]) -> pd.DataFrame:
+    """Count cashtags or exact uppercase symbols from an explicit universe; one mention/post."""
+    import re
+
+    if not {"text", "id"} <= set(posts) or posts.id.duplicated().any():
+        raise ValueError("unique post ids and text required")
+    rows = []
+    for ticker in dict.fromkeys(tickers):
+        pattern = re.compile(r"(?<![A-Za-z0-9])\$?" + re.escape(ticker) + r"(?![A-Za-z0-9])")
+        selected = posts[posts.text.map(lambda text, pattern=pattern: bool(pattern.search(text)))]
+        if len(selected):
+            scores = sentiment(selected.text.tolist())
+            rows.append(
+                {"ticker": ticker, "posts": len(selected), "compound": scores.compound.mean()}
+            )
+    return pd.DataFrame(rows, columns=["ticker", "posts", "compound"]).sort_values(
+        "posts", ascending=False
+    )

--- a/src/finance/backtesting/__init__.py
+++ b/src/finance/backtesting/__init__.py
@@ -1,3 +1,4 @@
 from .engine import BacktestResult, backtest
+from .trades import completed_trades, trade_statistics
 
-__all__ = ["BacktestResult", "backtest"]
+__all__ = ["BacktestResult", "backtest", "completed_trades", "trade_statistics"]

--- a/src/finance/backtesting/engine.py
+++ b/src/finance/backtesting/engine.py
@@ -30,12 +30,20 @@ def backtest(
     periods: int = 252,
     rebalance: bool = False,
     liquidate: bool = False,
+    high_prices: pd.Series | pd.DataFrame | None = None,
+    low_prices: pd.Series | pd.DataFrame | None = None,
+    stop_loss: float | None = None,
+    take_profit: float | None = None,
+    trailing_fraction: float | None = None,
 ) -> BacktestResult:
     """Close signals execute next open. Gross target <=1; fractional shares, no cash interest.
 
     Rebalance on target changes (or every bar with rebalance=True). Trade rows are fills,
     including partial adjustments. Adjusted OHLC must share a basis. Short borrow is charged
-    on each held bar's opening notional. No intrabar stops, margin loans, or volume limits.
+    on each held bar's opening notional. Optional protective orders require high/low data.
+    Ambiguous same-bar stop/target hits use stop first; gaps fill at open. Trailing levels
+    update after the bar and stopped positions rearm only when the source target changes.
+    No margin loans or volume limits.
     """
 
     def as_frame(data):
@@ -61,11 +69,34 @@ def backtest(
         finite(cost, name, minimum=0)
         if cost >= 1:
             raise ValueError(f"{name} must be below 1")
+    protective = any(x is not None for x in (stop_loss, take_profit, trailing_fraction))
+    for fraction in (stop_loss, take_profit, trailing_fraction):
+        if fraction is not None and (not np.isfinite(fraction) or not 0 < fraction < 1):
+            raise ValueError("protective order fractions must be in (0,1)")
+    if protective:
+        if high_prices is None or low_prices is None:
+            raise ValueError("protective orders require high_prices and low_prices")
+        highs, lows = (
+            frame(as_frame(high_prices), positive=True),
+            frame(as_frame(low_prices), positive=True),
+        )
+        for data in (highs, lows):
+            if not data.index.equals(opens.index) or not data.columns.equals(opens.columns):
+                raise ValueError("protective OHLC must align exactly")
+        if (
+            ((highs < opens) | (highs < closes) | (lows > opens) | (lows > closes) | (lows > highs))
+            .any()
+            .any()
+        ):
+            raise ValueError("inconsistent OHLC bounds")
     window_size(periods)
     cash, shares = float(initial_cash), np.zeros(opens.shape[1])
     cash_rows, equity_rows, holding_rows, fills = [], [], [], []
     prior_target = np.zeros(opens.shape[1])
     fees_total = borrow_total = 0.0
+    stopped = np.zeros(opens.shape[1], dtype=bool)
+    entries = np.zeros(opens.shape[1])
+    extremes = np.zeros(opens.shape[1])
     open_values, close_values = opens.to_numpy(), closes.to_numpy()
     # At bar t only the signal from t-1 is available.
     delayed = targets.shift(1, fill_value=0).to_numpy()
@@ -93,11 +124,14 @@ def backtest(
             )
 
     for i, timestamp in enumerate(opens.index):
-        price, close, target = open_values[i], close_values[i], delayed[i]
+        price, close, source_target = open_values[i], close_values[i], delayed[i]
+        stopped[source_target != prior_target] = False
+        target = np.where(stopped, 0, source_target)
+        previous_shares = shares.copy()
         equity_at_open = cash + shares @ price
         if equity_at_open <= 0:
             raise ValueError(f"account insolvent at {timestamp}; short losses exceeded equity")
-        if rebalance or not np.array_equal(target, prior_target):
+        if rebalance or not np.array_equal(source_target, prior_target):
             # Solve for post-cost equity so a fully invested long never overspends cash.
             def residual(equity, target=target, price=price, equity_at_open=equity_at_open):
                 quantity = target * equity / price - shares
@@ -116,10 +150,51 @@ def backtest(
                     lower = middle
             desired = target * ((lower + upper) / 2) / price
             execute(desired - shares, price, timestamp, opens.index[i - 1] if i else pd.NaT, "open")
-        prior_target = target.copy()
+        prior_target = source_target.copy()
+        new_position = (shares != 0) & (np.sign(shares) != np.sign(previous_shares))
+        entries[new_position] = price[new_position] * (1 + np.sign(shares[new_position]) * slippage)
+        extremes[new_position] = entries[new_position]
         borrow = np.maximum(-shares, 0) @ price * borrow_rate / periods
         cash -= borrow
         borrow_total += borrow
+        if protective:
+            high, low = highs.iloc[i].to_numpy(), lows.iloc[i].to_numpy()
+            for j in range(len(shares)):
+                side = np.sign(shares[j])
+                if not side:
+                    continue
+                stop = entries[j] * (1 - side * stop_loss) if stop_loss else None
+                if trailing_fraction:
+                    trail = extremes[j] * (1 - side * trailing_fraction)
+                    stop = (
+                        trail
+                        if stop is None
+                        else (max(stop, trail) if side > 0 else min(stop, trail))
+                    )
+                profit = entries[j] * (1 + side * take_profit) if take_profit else None
+                stop_hit = stop is not None and (low[j] <= stop if side > 0 else high[j] >= stop)
+                profit_hit = profit is not None and (
+                    high[j] >= profit if side > 0 else low[j] <= profit
+                )
+                profit_gap = profit is not None and (
+                    price[j] >= profit if side > 0 else price[j] <= profit
+                )
+                if stop_hit or profit_hit:
+                    if profit_gap:
+                        fill, phase = price[j], "take_profit"
+                    elif stop_hit:
+                        fill = min(price[j], stop) if side > 0 else max(price[j], stop)
+                        phase = "stop"
+                    else:
+                        fill, phase = profit, "take_profit"
+                    quantity, prices = np.zeros(len(shares)), price.copy()
+                    quantity[j], prices[j] = -shares[j], fill
+                    execute(quantity, prices, timestamp, pd.NaT, phase)
+                    stopped[j] = True
+                else:
+                    extremes[j] = (
+                        max(extremes[j], high[j]) if side > 0 else min(extremes[j], low[j])
+                    )
         if liquidate and i == len(opens) - 1:
             execute(-shares.copy(), close, timestamp, pd.NaT, "final_close")
         equity = cash + shares @ close

--- a/src/finance/backtesting/trades.py
+++ b/src/finance/backtesting/trades.py
@@ -1,0 +1,109 @@
+"""FIFO matching of fills; open quantities remain unrealized."""
+
+from collections import defaultdict, deque
+
+import numpy as np
+import pandas as pd
+
+
+def completed_trades(fills: pd.DataFrame) -> pd.DataFrame:
+    """One row per matched lot portion; commissions allocated by quantity, excludes borrow costs."""
+    required = ["date", "asset", "quantity", "price", "commission"]
+    if not set(required) <= set(fills):
+        raise ValueError(f"required fill columns: {required}")
+    values = fills[["quantity", "price", "commission"]]
+    if (
+        not np.isfinite(values).all().all()
+        or (fills.price <= 0).any()
+        or (fills.commission < 0).any()
+    ):
+        raise ValueError("finite quantities, positive prices and nonnegative fees required")
+    if not pd.Index(fills.date).is_monotonic_increasing:
+        raise ValueError("fills must be chronological, preserving within-bar execution order")
+    lots, rows = defaultdict(deque), []
+    for fill in fills.itertuples():
+        remaining = float(fill.quantity)
+        if remaining == 0:
+            if fill.commission != 0:
+                raise ValueError("zero-quantity fills cannot carry commissions")
+            continue
+        fee_per_share = fill.commission / abs(remaining)
+        book = lots[fill.asset]
+        while book and np.sign(book[0]["quantity"]) != np.sign(remaining):
+            lot = book[0]
+            matched = min(abs(lot["quantity"]), abs(remaining))
+            side = np.sign(lot["quantity"])
+            gross = side * matched * (fill.price - lot["price"])
+            fees = matched * (lot["fee"] + fee_per_share)
+            rows.append(
+                {
+                    "asset": fill.asset,
+                    "entry_date": lot["date"],
+                    "exit_date": fill.date,
+                    "side": "long" if side > 0 else "short",
+                    "quantity": matched,
+                    "entry_price": lot["price"],
+                    "exit_price": fill.price,
+                    "gross_pnl": gross,
+                    "commission": fees,
+                    "net_pnl": gross - fees,
+                    "return": (gross - fees) / (matched * lot["price"]),
+                    "duration": pd.Timestamp(fill.date) - pd.Timestamp(lot["date"]),
+                }
+            )
+            lot["quantity"] -= side * matched
+            remaining += side * matched
+            if abs(lot["quantity"]) < 1e-10:
+                book.popleft()
+            if abs(remaining) < 1e-10:
+                remaining = 0
+                break
+        if remaining:
+            book.append(
+                {
+                    "quantity": remaining,
+                    "price": fill.price,
+                    "date": fill.date,
+                    "fee": fee_per_share,
+                }
+            )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "asset",
+            "entry_date",
+            "exit_date",
+            "side",
+            "quantity",
+            "entry_price",
+            "exit_price",
+            "gross_pnl",
+            "commission",
+            "net_pnl",
+            "return",
+            "duration",
+        ],
+    )
+
+
+def trade_statistics(trades: pd.DataFrame) -> pd.Series:
+    if not {"net_pnl", "return", "duration"} <= set(trades):
+        raise ValueError("provide completed_trades output")
+    wins, losses = (
+        trades.loc[trades.net_pnl > 0, "net_pnl"],
+        trades.loc[trades.net_pnl < 0, "net_pnl"],
+    )
+    return pd.Series(
+        {
+            "matched_lots": len(trades),
+            "win_rate": (trades.net_pnl > 0).mean(),
+            "average_win": wins.mean(),
+            "average_loss": losses.mean(),
+            "profit_factor": wins.sum() / -losses.sum() if len(losses) else np.nan,
+            "net_pnl": trades.net_pnl.sum(),
+            "mean_return": trades["return"].mean(),
+            "mean_holding_days": trades.duration.dt.total_seconds().mean() / 86400
+            if len(trades)
+            else np.nan,
+        }
+    )

--- a/src/finance/data/__init__.py
+++ b/src/finance/data/__init__.py
@@ -1,3 +1,5 @@
+from .content import article_text, reddit_posts, rss_news, transcript_index
+from .finviz import Finviz
 from .normalize import normalize_ohlcv, normalize_ticker
 from .providers import (
     PriceProvider,
@@ -9,6 +11,8 @@ from .providers import (
     exchange_universe,
     sp500_constituents,
 )
+from .research import BatchResult, earnings_calendar, fetch_many, snapshot_changes
+from .tradingview import TradingView
 
 __all__ = [
     "normalize_ticker",
@@ -21,4 +25,14 @@ __all__ = [
     "close_matrix",
     "dividend_calendar",
     "cot_financial_futures",
+    "Finviz",
+    "BatchResult",
+    "fetch_many",
+    "snapshot_changes",
+    "earnings_calendar",
+    "article_text",
+    "reddit_posts",
+    "rss_news",
+    "transcript_index",
+    "TradingView",
 ]

--- a/src/finance/data/content.py
+++ b/src/finance/data/content.py
@@ -1,0 +1,90 @@
+"""Public feeds and article text; availability depends on each publisher."""
+
+import re
+from urllib.parse import quote
+from xml.etree import ElementTree
+
+import pandas as pd
+
+from finance.data.providers import ProviderError
+from finance.data.web import PublicWeb
+
+
+def rss_news(url: str, *, web: PublicWeb | None = None) -> pd.DataFrame:
+    body = (web or PublicWeb()).text(url)
+    try:
+        root = ElementTree.fromstring(body)
+    except ElementTree.ParseError as exc:
+        raise ProviderError("Feed is not valid XML") from exc
+    records = []
+    for item in root.findall(".//item"):
+        title, link = item.findtext("title"), item.findtext("link")
+        if title and link:
+            records.append({"title": title, "url": link, "published": item.findtext("pubDate")})
+    if not records:
+        raise ProviderError("No RSS news items found")
+    result = pd.DataFrame(records).drop_duplicates("url")
+    result["published"] = pd.to_datetime(result.published, utc=True, errors="raise")
+    return result.reset_index(drop=True)
+
+
+def article_text(url: str, *, web: PublicWeb | None = None) -> str:
+    """Extract a publicly accessible article/transcript by URL; no login or paywall fallback."""
+    from lxml import html
+
+    root = html.fromstring((web or PublicWeb()).text(url))
+    articles = root.xpath('//*[@id="article-body-transcript"]') or root.xpath("//article")
+    if not articles:
+        raise ProviderError("No article element; publisher needs a dedicated parser")
+    article = max(articles, key=lambda node: len(node.text_content()))
+    paragraphs = [" ".join(p.text_content().split()) for p in article.xpath(".//p")]
+    result = "\n\n".join(p for p in paragraphs if p)
+    if len(result) < 200:
+        raise ProviderError("Article is missing or truncated")
+    return result
+
+
+def reddit_posts(subreddit: str, limit: int = 25, *, web: PublicWeb | None = None) -> pd.DataFrame:
+    """Public recent posts; fail explicitly if Reddit requires authenticated access."""
+    if not re.fullmatch(r"\w{2,30}", subreddit) or not 1 <= limit <= 100:
+        raise ValueError("invalid subreddit or limit")
+    payload = (web or PublicWeb()).json(
+        f"https://www.reddit.com/r/{quote(subreddit)}/new.json?limit={limit}&raw_json=1"
+    )
+    try:
+        rows = [item["data"] for item in payload["data"]["children"]]
+        result = pd.DataFrame(
+            [
+                {
+                    "id": r["id"],
+                    "text": r["title"] + "\n" + r.get("selftext", ""),
+                    "published": pd.to_datetime(r["created_utc"], unit="s", utc=True),
+                    "score": r["score"],
+                    "url": "https://www.reddit.com" + r["permalink"],
+                }
+                for r in rows
+            ]
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ProviderError("Reddit response schema changed") from exc
+    return result
+
+
+def transcript_index(*, web: PublicWeb | None = None) -> pd.DataFrame:
+    """Discover recent publicly listed Motley Fool transcripts; not a complete historical archive."""
+    from urllib.parse import urljoin
+
+    from lxml import html
+
+    url = "https://www.fool.com/earnings-call-transcripts/"
+    root = html.fromstring((web or PublicWeb()).text(url))
+    records = []
+    for link in root.xpath("//a[@href]"):
+        href = link.get("href")
+        if "/earnings/call-transcripts/" in href:
+            title = " ".join(link.text_content().split())
+            if title:
+                records.append({"title": title, "url": urljoin(url, href)})
+    if not records:
+        raise ProviderError("Transcript index has no article links")
+    return pd.DataFrame(records).drop_duplicates("url").reset_index(drop=True)

--- a/src/finance/data/finviz.py
+++ b/src/finance/data/finviz.py
@@ -1,0 +1,350 @@
+"""Public Finviz snapshots. Percentages are fractions; source symbols are preserved."""
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, urlencode, urljoin, urlparse
+
+import numpy as np
+import pandas as pd
+
+from finance.data.providers import ProviderError
+from finance.data.web import PublicWeb
+
+
+def number(value: str) -> float:
+    value = value.strip().replace(",", "").replace("$", "").replace("−", "-")
+    if value in ("", "-", "--", "N/A", "None"):
+        return np.nan
+    scale = {"K": 1e3, "M": 1e6, "B": 1e9, "T": 1e12, "%": 0.01}
+    factor = scale.get(value[-1], 1)
+    if value[-1] in scale:
+        value = value[:-1]
+    try:
+        result = float(value) * factor
+        if not np.isfinite(result):
+            raise ValueError("nonfinite number")
+        return result
+    except ValueError as exc:
+        raise ProviderError(f"Unexpected numeric field: {value!r}") from exc
+
+
+def _root(body):
+    from lxml import html
+
+    return html.fromstring(body)
+
+
+def _text(node):
+    return " ".join(node.text_content().split())
+
+
+def _symbol(cell):
+    for link in cell.xpath(".//a[@href]"):
+        query = parse_qs(urlparse(link.get("href")).query)
+        if "t" in query:
+            return query["t"][0]
+    raise ProviderError("Ticker link missing from Finviz row")
+
+
+def _table(root, required):
+    for table in root.xpath("//table"):
+        rows = table.xpath("./tr|./thead/tr|./tbody/tr")
+        if not rows:
+            continue
+        headers = [_text(cell) for cell in rows[0].xpath("./td|./th")]
+        if set(required) <= set(headers):
+            return headers, rows[1:]
+    raise ProviderError(f"Finviz table missing columns {required}")
+
+
+def _stamp(result, url):
+    result.attrs.update(
+        source=url, retrieved_at=pd.Timestamp.now(tz="UTC").isoformat(), historical=False
+    )
+    return result
+
+
+@dataclass
+class Finviz:
+    web: PublicWeb = field(default_factory=PublicWeb)
+
+    def _get(self, path, **params):
+        url = "https://finviz.com/" + path + ("?" + urlencode(params) if params else "")
+        return _root(self.web.text(url)), url
+
+    def screen(
+        self, filters: list[str] | None = None, *, order: str = "ticker", limit: int = 100
+    ) -> pd.DataFrame:
+        """Provider filter codes, e.g. cap_largeover,fa_epsqoq_o10. Explicit limit; attrs show completeness."""
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 10000:
+            raise ValueError("limit must be an integer in [1,10000]")
+        if any(not re.fullmatch(r"[\w.-]+", item) for item in [order, *(filters or [])]):
+            raise ValueError("invalid Finviz filter/order code")
+        records, total = [], None
+        url = ""
+        for offset in range(1, limit + 1, 20):
+            root, url = self._get(
+                "screener.ashx", v=111, f=",".join(filters or []), o=order, r=offset
+            )
+            text = _text(root)
+            match = re.search(r"/\s*([\d,]+)\s+Total", text)
+            if match:
+                count = int(match[1].replace(",", ""))
+                if total is not None and count != total:
+                    raise ProviderError("Screener changed during pagination; retry the snapshot")
+                total = count
+            if total == 0:
+                break
+            headers, rows = _table(root, ["Ticker", "Company", "Market Cap", "Price"])
+            page = []
+            for row in rows:
+                cells = row.xpath("./td")
+                if len(cells) != len(headers):
+                    continue
+                values = dict(zip(headers, cells, strict=True))
+                page.append(
+                    {
+                        "ticker": _symbol(values["Ticker"]),
+                        "name": _text(values["Company"]),
+                        "sector": _text(values["Sector"]),
+                        "industry": _text(values["Industry"]),
+                        "country": _text(values["Country"]),
+                        "market_cap": number(_text(values["Market Cap"])),
+                        "pe": number(_text(values["P/E"])),
+                        "price": number(_text(values["Price"])),
+                        "change": number(_text(values["Change %"])),
+                        "volume": number(_text(values["Volume"])),
+                    }
+                )
+            if not page:
+                raise ProviderError("Finviz returned no parseable screener rows")
+            records.extend(page)
+            if total is not None and len(records) >= total:
+                break
+        result = pd.DataFrame(
+            records,
+            columns=[
+                "ticker",
+                "name",
+                "sector",
+                "industry",
+                "country",
+                "market_cap",
+                "pe",
+                "price",
+                "change",
+                "volume",
+            ],
+        ).set_index("ticker")
+        if result.index.has_duplicates:
+            raise ProviderError("Duplicate tickers across screener pages; retry the snapshot")
+        if total is None:
+            raise ProviderError("Finviz total count missing; completeness cannot be established")
+        result = result.iloc[:limit]
+        result.attrs.update(
+            total_matches=total, complete=len(result) == total, filters=filters or []
+        )
+        return _stamp(result, url)
+
+    def universe(self, index: str, *, limit: int = 3000) -> pd.DataFrame:
+        codes = {"sp500": "sp500", "dow": "dji", "nasdaq100": "ndx", "russell2000": "rut"}
+        if index not in codes:
+            raise ValueError(f"index must be one of {list(codes)}")
+        return self.screen([f"idx_{codes[index]}"], limit=limit)
+
+    def company(self, ticker: str) -> pd.Series:
+        root, url = self._get("quote.ashx", t=ticker)
+        fields = {
+            "Market Cap": "market_cap",
+            "Enterprise Value": "enterprise_value",
+            "P/E": "pe",
+            "Forward P/E": "forward_pe",
+            "PEG": "peg",
+            "P/S": "price_sales",
+            "P/B": "price_book",
+            "P/FCF": "price_fcf",
+            "ROE": "roe",
+            "ROA": "roa",
+            "ROIC": "roic",
+            "Gross Margin": "gross_margin",
+            "Oper. Margin": "operating_margin",
+            "Profit Margin": "profit_margin",
+            "EPS Q/Q": "earnings_growth",
+            "Sales Q/Q": "revenue_growth",
+            "EPS Y/Y TTM": "earnings_growth_ttm",
+            "Sales Y/Y TTM": "revenue_growth_ttm",
+            "EPS next 5Y": "expected_earnings_growth_5y",
+            "Insider Own": "insider_ownership",
+            "Insider Trans": "insider_transactions",
+            "Inst Own": "institutional_ownership",
+            "Inst Trans": "institutional_transactions",
+            "SMA20": "distance_sma20",
+            "SMA50": "distance_sma50",
+            "SMA200": "distance_sma200",
+            "RSI (14)": "rsi",
+            "Rel Volume": "relative_volume",
+            "Avg Volume": "average_volume",
+            "Volume": "volume",
+            "Price": "price",
+            "Target Price": "target_price",
+            "Recom": "analyst_rating",
+            "Shs Outstand": "shares",
+            "Short Float": "short_float",
+            "Beta": "beta",
+            "Debt/Eq": "debt_equity",
+            "Perf Year": "return_1y",
+            "Perf Quarter": "return_quarter",
+            "Perf Month": "return_month",
+        }
+        result, raw = {}, {}
+        for row in root.xpath('//table[contains(@class,"snapshot-table2")]//tr'):
+            cells = row.xpath("./td")
+            for i in range(0, len(cells) - 1, 2):
+                label, value = _text(cells[i]), _text(cells[i + 1])
+                # Some source labels are duplicated (EPS next Y amount versus growth).
+                raw.setdefault(label, []).append(value)
+                if label in fields:
+                    result[fields[label]] = number(value)
+                if label == "EPS next Y":
+                    result["expected_earnings_growth" if "%" in value else "expected_eps"] = number(
+                        value
+                    )
+                if label in ("52W High", "52W Low"):
+                    parts = value.split()
+                    if len(parts) == 2:
+                        suffix = "high" if label.endswith("High") else "low"
+                        result[f"{suffix}_52w"] = number(parts[0])
+                        result[f"distance_{suffix}_52w"] = number(parts[1])
+                if label == "Dividend TTM":
+                    match = re.fullmatch(r"([\d.,]+)\s*\(([\d.]+%)\)", value)
+                    if match:
+                        result["annual_dividend"], result["dividend_yield"] = (
+                            number(match[1]),
+                            number(match[2]),
+                        )
+        if not {"price", "market_cap", "pe", "roe"} <= result.keys():
+            raise ProviderError(f"Finviz company schema missing for {ticker}")
+        if not np.isfinite(result["price"]) or result["price"] <= 0:
+            raise ProviderError(f"Invalid Finviz price for {ticker}")
+        output = pd.Series(result, name=ticker)
+        output.attrs["raw_fields"] = raw
+        return _stamp(output, url)
+
+    def analysts(self, ticker: str) -> pd.DataFrame:
+        root, url = self._get("quote.ashx", t=ticker)
+        headers, rows = _table(
+            root, ["Date", "Action", "Analyst", "Rating Change", "Price Target Change"]
+        )
+        values = [[_text(c) for c in row.xpath("./td")] for row in rows]
+        result = pd.DataFrame([v for v in values if len(v) == len(headers)], columns=headers)
+        result.columns = ["date", "action", "analyst", "rating_change", "target_change"]
+        result["date"] = pd.to_datetime(result.date, format="%b-%d-%y", errors="raise")
+        return _stamp(result, url)
+
+    def insiders(self) -> pd.DataFrame:
+        root, url = self._get("insidertrading.ashx")
+        headers, rows = _table(
+            root, ["Ticker", "Owner", "Transaction", "Cost", "#Shares", "Value ($)"]
+        )
+        records = []
+        for row in rows:
+            cells = row.xpath("./td")
+            if len(cells) != len(headers):
+                continue
+            values = dict(zip(headers, cells, strict=True))
+            records.append(
+                {
+                    "ticker": _symbol(values["Ticker"]),
+                    "owner": _text(values["Owner"]),
+                    "relationship": _text(values["Relationship"]),
+                    "date": _text(values["Date"]),
+                    "transaction": _text(values["Transaction"]),
+                    "price": number(_text(values["Cost"])),
+                    "shares": number(_text(values["#Shares"])),
+                    "value": number(_text(values["Value ($)"])),
+                    "filing": _text(values["SEC Form 4"]),
+                }
+            )
+        if not records:
+            raise ProviderError("No insider rows parsed")
+        result = pd.DataFrame(records)
+        result["date"] = pd.to_datetime(result.date, format="%b %d '%y", errors="raise")
+        return _stamp(result, url)
+
+    def news(self, ticker: str | None = None) -> pd.DataFrame:
+        root, url = self._get("quote.ashx", t=ticker) if ticker else self._get("news.ashx")
+        selector = (
+            '//table[@id="news-table"]//tr'
+            if ticker
+            else '//table[contains(@class,"styled-table-new")]//tr'
+        )
+        records = []
+        for row in root.xpath(selector):
+            links = row.xpath('.//a[starts-with(@href,"http")]')
+            if not links:
+                continue
+            link = max(links, key=lambda a: len(_text(a)))
+            if not _text(link):
+                continue
+            records.append(
+                {
+                    "ticker": ticker,
+                    "title": _text(link),
+                    "url": urljoin(url, link.get("href")),
+                    "source_time": next(
+                        (
+                            m.group()
+                            for m in [
+                                re.search(
+                                    r"(?:[A-Z][a-z]{2}-\d{2}-\d{2} |Today )?\d{2}:\d{2}[AP]M",
+                                    _text(row),
+                                )
+                            ]
+                            if m
+                        ),
+                        "",
+                    ),
+                }
+            )
+        if not records:
+            raise ProviderError("No news stories parsed")
+        return _stamp(pd.DataFrame(records).drop_duplicates("url").reset_index(drop=True), url)
+
+    def market(self) -> dict[str, pd.DataFrame]:
+        """Homepage movers, macro releases, futures and FX snapshots. Source time/units retained."""
+        root, url = self._get("")
+        result = {}
+        for name, required in [
+            ("movers", ["Ticker", "Last", "Change %", "Volume", "", "Signal"]),
+            (
+                "economy",
+                ["Date", "Time", "Impact", "Release", "For", "Actual", "Expected", "Prior"],
+            ),
+            ("futures", ["Futures", "Last", "Change", "Change %"]),
+            ("forex", ["Forex & Bonds", "Last", "Change", "Change %"]),
+        ]:
+            tables = []
+            for table in root.xpath("//table"):
+                rows = table.xpath("./tr|./thead/tr|./tbody/tr")
+                if not rows:
+                    continue
+                headers = [_text(c) for c in rows[0].xpath("./td|./th")]
+                if headers != required:
+                    continue
+                values = []
+                for row in rows[1:]:
+                    cells = row.xpath("./td")
+                    if len(cells) == len(headers):
+                        values.append(
+                            [
+                                _symbol(cells[0]) if name == "movers" else _text(cells[0]),
+                                *[_text(c) for c in cells[1:]],
+                            ]
+                        )
+                tables.append(pd.DataFrame(values, columns=headers))
+            if not tables:
+                raise ProviderError(f"Finviz {name} table missing")
+            result[name] = _stamp(
+                pd.concat(tables, ignore_index=True).drop(columns=[""], errors="ignore"), url
+            )
+        return result

--- a/src/finance/data/providers.py
+++ b/src/finance/data/providers.py
@@ -59,7 +59,6 @@ class YahooFinance:
                 auto_adjust=self.adjusted,
                 actions=False,
                 timeout=self.timeout,
-                raise_errors=True,
             )
             result = normalize_ohlcv(raw)
         except Exception as exc:
@@ -80,7 +79,6 @@ class YahooFinance:
                 auto_adjust=False,
                 actions=True,
                 timeout=self.timeout,
-                raise_errors=True,
             )
             if raw.empty or "Dividends" not in raw:
                 raise ValueError("missing dividend history")
@@ -124,6 +122,33 @@ class YahooFinance:
             return result
         except Exception as exc:
             raise ProviderError(f"Yahoo company failed for {ticker}: {exc}") from exc
+
+    def statements(
+        self, ticker: str, kind: str = "income", frequency: str = "annual"
+    ) -> pd.DataFrame:
+        """Period-end rows, provider statement labels, reported currency units; restatements possible."""
+        names = {"income": "income_stmt", "balance": "balance_sheet", "cashflow": "cashflow"}
+        if kind not in names or frequency not in ("annual", "quarterly"):
+            raise ValueError("kind: income/balance/cashflow; frequency: annual/quarterly")
+        handle = self._ticker(ticker)
+        attribute = ("quarterly_" if frequency == "quarterly" else "") + names[kind]
+        try:
+            raw = getattr(handle, attribute)
+            if not isinstance(raw, pd.DataFrame) or raw.empty or raw.index.has_duplicates:
+                raise ValueError("missing or duplicate statement fields")
+            result = raw.T.apply(pd.to_numeric, errors="raise").sort_index().dropna(how="all")
+            result.index = pd.DatetimeIndex(result.index, name="period_end")
+            result.attrs.update(
+                provider="Yahoo Finance",
+                ticker=ticker,
+                frequency=frequency,
+                retrieved_at=pd.Timestamp.now(tz="UTC").isoformat(),
+                currency=handle.get_info().get("financialCurrency"),
+                restated=True,
+            )
+            return result
+        except Exception as exc:
+            raise ProviderError(f"Yahoo {kind} statement failed for {ticker}: {exc}") from exc
 
     def earnings(self, ticker: str) -> pd.DataFrame:
         return self._table(ticker, "get_earnings_dates", ["EPS Estimate", "Reported EPS"])

--- a/src/finance/data/research.py
+++ b/src/finance/data/research.py
@@ -1,0 +1,90 @@
+"""Batch acquisition, public calendars and timestamped snapshot comparisons."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import pandas as pd
+
+from finance.data.providers import ProviderError
+from finance.data.web import PublicWeb
+
+
+@dataclass(frozen=True)
+class BatchResult:
+    data: dict
+    errors: pd.Series
+
+    def table(self) -> pd.DataFrame:
+        """One row per successful company snapshot; failures remain in errors."""
+        return pd.DataFrame(self.data).T
+
+
+def fetch_many(tickers: Iterable[str], fetch: Callable) -> BatchResult:
+    """Sequential requests respect the provider's rate limits; no silent dropped symbols."""
+    if isinstance(tickers, str):
+        raise ValueError("provide a sequence of tickers")
+    data, errors = {}, {}
+    for ticker in dict.fromkeys(tickers):
+        try:
+            data[ticker] = fetch(ticker)
+        except ProviderError as exc:
+            errors[ticker] = str(exc)
+    return BatchResult(data, pd.Series(errors, dtype=str, name="error"))
+
+
+def snapshot_changes(before: pd.DataFrame, after: pd.DataFrame) -> pd.DataFrame:
+    """Changes between observations; does not infer when the underlying event occurred."""
+    if not before.index.is_unique or not after.index.is_unique:
+        raise ValueError("snapshot row keys must be unique")
+    rows = []
+    for key in before.index.union(after.index):
+        for column in before.columns.union(after.columns):
+            old = before.at[key, column] if key in before.index and column in before else None
+            new = after.at[key, column] if key in after.index and column in after else None
+            if (pd.isna(old) and pd.isna(new)) or (pd.notna(old) and pd.notna(new) and old == new):
+                continue
+            rows.append({"key": key, "field": column, "before": old, "after": new})
+    return pd.DataFrame(rows, columns=["key", "field", "before", "after"])
+
+
+def earnings_calendar(start: str, end: str, *, web: PublicWeb | None = None) -> pd.DataFrame:
+    """Nasdaq calendar, start inclusive/end exclusive, at most 31 days per request."""
+    start, end = pd.Timestamp(start), pd.Timestamp(end)
+    if start >= end or end - start > pd.Timedelta(days=31):
+        raise ValueError("provide a date range of 1–31 days")
+    web = web or PublicWeb()
+    rows = []
+    for day in pd.date_range(start, end, inclusive="left"):
+        payload = web.json(
+            "https://api.nasdaq.com/api/calendar/earnings?"
+            + urlencode({"date": day.strftime("%Y-%m-%d")})
+        )
+        data = payload.get("data")
+        if not isinstance(data, dict) or "rows" not in data:
+            raise ProviderError(f"Nasdaq earnings calendar unavailable for {day.date()}")
+        for row in data["rows"] or []:
+            if not {"symbol", "name", "epsForecast", "fiscalQuarterEnding"} <= row.keys():
+                raise ProviderError("Nasdaq earnings schema changed")
+            rows.append(
+                {
+                    "date": day,
+                    "ticker": row["symbol"],
+                    "name": row["name"],
+                    "session": row.get("time"),
+                    "eps_estimate": row["epsForecast"],
+                    "quarter_end": row["fiscalQuarterEnding"],
+                }
+            )
+    result = pd.DataFrame(
+        rows, columns=["date", "ticker", "name", "session", "eps_estimate", "quarter_end"]
+    )
+    result["eps_estimate"] = pd.to_numeric(
+        result.eps_estimate.astype("string")
+        .str.replace("$", "", regex=False)
+        .str.replace(r"^\((.*)\)$", r"-\1", regex=True)
+        .replace({"N/A": None, "--": None}),
+        errors="raise",
+    )
+    result.attrs.update(source="Nasdaq", retrieved_at=pd.Timestamp.now(tz="UTC").isoformat())
+    return result

--- a/src/finance/data/tradingview.py
+++ b/src/finance/data/tradingview.py
@@ -1,0 +1,87 @@
+"""Public scanner snapshots, an undocumented provider interface subject to change."""
+
+import json
+import re
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import numpy as np
+import pandas as pd
+
+from finance.data.providers import ProviderError
+
+
+@dataclass(frozen=True)
+class TradingView:
+    timeout: float = 20
+
+    def recommendations(self, symbols: list[str], interval: str = "1d") -> pd.DataFrame:
+        """Exchange-qualified symbols; vendor numeric recommendations in [-1,1], current snapshots."""
+        suffixes = {
+            "1m": "|1",
+            "5m": "|5",
+            "15m": "|15",
+            "1h": "|60",
+            "4h": "|240",
+            "1d": "",
+            "1w": "|1W",
+            "1mo": "|1M",
+        }
+        if (
+            interval not in suffixes
+            or not symbols
+            or len(symbols) > 100
+            or len(set(symbols)) != len(symbols)
+        ):
+            raise ValueError("supported interval and 1–100 distinct symbols required")
+        if self.timeout <= 0 or any(
+            not re.fullmatch(r"[A-Z0-9_]+:[A-Z0-9_.!-]+", s) for s in symbols
+        ):
+            raise ValueError("positive timeout and EXCHANGE:SYMBOL identifiers required")
+        columns = [
+            name + suffixes[interval]
+            for name in ["close", "Recommend.All", "Recommend.MA", "Recommend.Other"]
+        ]
+        payload = {
+            "symbols": {"tickers": symbols, "query": {"types": []}},
+            "columns": columns,
+            "range": [0, len(symbols)],
+        }
+        request = Request(
+            "https://scanner.tradingview.com/america/scan",
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"},
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                raw = json.load(response)
+            rows = [
+                {
+                    "symbol": row["s"],
+                    **dict(
+                        zip(
+                            ["price", "overall", "moving_averages", "oscillators"],
+                            row["d"],
+                            strict=True,
+                        )
+                    ),
+                }
+                for row in raw["data"]
+            ]
+            result = pd.DataFrame(rows).set_index("symbol").reindex(symbols)
+            if (
+                not np.isfinite(result).all().all()
+                or (result.price <= 0).any()
+                or (result.drop(columns="price").abs() > 1).any().any()
+            ):
+                raise ValueError("missing symbols or invalid recommendations")
+            result.attrs.update(
+                provider="TradingView public scanner",
+                interval=interval,
+                retrieved_at=pd.Timestamp.now(tz="UTC").isoformat(),
+                historical=False,
+            )
+            return result
+        except (HTTPError, URLError, TimeoutError, ValueError, KeyError, TypeError) as exc:
+            raise ProviderError(f"TradingView scanner failed: {exc}") from exc

--- a/src/finance/data/web.py
+++ b/src/finance/data/web.py
@@ -1,0 +1,53 @@
+"""Bounded public-page retrieval; parsing stays in each provider."""
+
+import json
+import time
+from dataclasses import dataclass, field
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from finance.data.providers import ProviderError
+
+
+@dataclass
+class PublicWeb:
+    timeout: float = 20
+    interval: float = 1
+    cache_seconds: float = 300
+    _cache: dict = field(default_factory=dict, init=False, repr=False)
+    _last_request: float = field(default=0, init=False, repr=False)
+
+    def text(self, url: str) -> str:
+        if self.timeout <= 0 or self.interval < 0 or self.cache_seconds < 0:
+            raise ValueError("positive timeout and nonnegative interval/cache required")
+        cached = self._cache.get(url)
+        if cached and time.monotonic() - cached[0] < self.cache_seconds:
+            return cached[1]
+        for attempt in range(3):
+            time.sleep(max(0, self.interval - (time.monotonic() - self._last_request)))
+            self._last_request = time.monotonic()
+            request = Request(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; FinanceToolkit research)",
+                    "Accept": "text/html,application/json,application/xml",
+                },
+            )
+            try:
+                with urlopen(request, timeout=self.timeout) as response:
+                    text = response.read().decode("utf-8")
+                self._cache[url] = (time.monotonic(), text)
+                return text
+            except HTTPError as exc:
+                if exc.code not in (429, 500, 502, 503, 504) or attempt == 2:
+                    raise ProviderError(f"HTTP {exc.code} from {url}") from exc
+                time.sleep(min(10, 2 ** (attempt + 1)))
+            except (URLError, TimeoutError, UnicodeError) as exc:
+                raise ProviderError(f"Unable to retrieve {url}: {exc}") from exc
+        raise ProviderError(f"Unable to retrieve {url}")
+
+    def json(self, url: str):
+        try:
+            return json.loads(self.text(url))
+        except ValueError as exc:
+            raise ProviderError(f"Expected JSON from {url}") from exc

--- a/src/finance/data/web.py
+++ b/src/finance/data/web.py
@@ -1,9 +1,11 @@
 """Bounded public-page retrieval; parsing stays in each provider."""
 
 import json
+import math
 import time
 from dataclasses import dataclass, field
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from finance.data.providers import ProviderError
@@ -18,8 +20,16 @@ class PublicWeb:
     _last_request: float = field(default=0, init=False, repr=False)
 
     def text(self, url: str) -> str:
-        if self.timeout <= 0 or self.interval < 0 or self.cache_seconds < 0:
+        if (
+            not all(math.isfinite(x) for x in (self.timeout, self.interval, self.cache_seconds))
+            or self.timeout <= 0
+            or self.interval < 0
+            or self.cache_seconds < 0
+        ):
             raise ValueError("positive timeout and nonnegative interval/cache required")
+        parsed = urlparse(url)
+        if parsed.scheme not in ("https", "http") or not parsed.netloc:
+            raise ValueError("public data requires an HTTP(S) URL")
         cached = self._cache.get(url)
         if cached and time.monotonic() - cached[0] < self.cache_seconds:
             return cached[1]

--- a/src/finance/indicators/__init__.py
+++ b/src/finance/indicators/__init__.py
@@ -3,10 +3,13 @@ from .levels import (
     breadth,
     confirmed_extrema,
     fibonacci_levels,
+    gann_fan,
     green_line,
     ichimoku,
     mcclellan,
+    pivot_midpoints,
     pivot_points,
+    speed_resistance,
 )
 from .momentum import (
     adx,
@@ -43,6 +46,7 @@ from .volatility import (
     donchian,
     envelopes,
     keltner,
+    natr,
     realized_volatility,
     relative_volatility_index,
     standard_deviation,
@@ -134,4 +138,9 @@ __all__ = [
     "ease_of_movement",
     "balance_of_power",
     "vpci",
+    "gann_fan",
+    "speed_resistance",
+    "natr",
 ]
+
+__all__ += ["pivot_midpoints"]

--- a/src/finance/indicators/levels.py
+++ b/src/finance/indicators/levels.py
@@ -149,3 +149,56 @@ def ichimoku(
     return pd.DataFrame(
         {"conversion": short, "base": long, "span_a": (short + long) / 2, "span_b": midpoint(span)}
     )
+
+
+def gann_fan(
+    bars: int,
+    anchor_price: float,
+    price_per_bar: float,
+    ratios: tuple[float, ...] = (0.125, 0.25, 0.5, 1, 2, 4, 8),
+) -> pd.DataFrame:
+    """Geometric drawing in explicit price/bar units; slopes are not chart-screen angles."""
+    window_size(bars)
+    finite(anchor_price, "anchor_price", minimum=0)
+    finite(price_per_bar, "price_per_bar")
+    if not ratios or not np.isfinite(ratios).all() or any(r <= 0 for r in ratios):
+        raise ValueError("positive finite slope ratios required")
+    steps = np.arange(bars)
+    return pd.DataFrame(
+        {f"{ratio:g}": anchor_price + price_per_bar * ratio * steps for ratio in ratios},
+        index=pd.Index(steps, name="bars_from_anchor"),
+    )
+
+
+def speed_resistance(
+    start_price: float, end_price: float, duration: int, bars: int
+) -> pd.DataFrame:
+    """One-third/two-thirds speed lines from a completed swing, available only at its end."""
+    window_size(duration)
+    window_size(bars)
+    finite(start_price, "start_price", minimum=0)
+    finite(end_price, "end_price", minimum=0)
+    result = gann_fan(bars, start_price, (end_price - start_price) / duration, (1 / 3, 2 / 3, 1))
+    result.iloc[: min(duration, bars)] = np.nan
+    return result
+
+
+def pivot_midpoints(levels: pd.DataFrame) -> pd.DataFrame:
+    """Midpoints between adjacent named support/pivot/resistance levels, preserving input timing."""
+    if "pivot" not in levels or levels.columns.has_duplicates:
+        raise ValueError("provide pivot_points output")
+    support = sorted(
+        [c for c in levels if c.startswith("s") and c[1:].isdigit()],
+        key=lambda c: int(c[1:]),
+        reverse=True,
+    )
+    resistance = sorted(
+        [c for c in levels if c.startswith("r") and c[1:].isdigit()], key=lambda c: int(c[1:])
+    )
+    names = [*support, "pivot", *resistance]
+    return pd.DataFrame(
+        {
+            f"{a}_{b}": (levels[a] + levels[b]) / 2
+            for a, b in zip(names[:-1], names[1:], strict=True)
+        }
+    )

--- a/src/finance/indicators/volatility.py
+++ b/src/finance/indicators/volatility.py
@@ -123,3 +123,9 @@ def supertrend(
             direction[i] = -1 if prices[i] < lower[i] else 1
         line[i] = lower[i] if direction[i] == 1 else upper[i]
     return pd.DataFrame({"supertrend": line, "direction": direction}, index=close.index)
+
+
+def natr(high: pd.Series, low: pd.Series, close: pd.Series, window: int = 14) -> pd.Series:
+    """Normalized ATR in percentage points (100 × ATR / close)."""
+    close = series(close, positive=True)
+    return (100 * atr(high, low, close, window) / close).rename("natr")

--- a/src/finance/integrations/__init__.py
+++ b/src/finance/integrations/__init__.py
@@ -1,0 +1,14 @@
+from .broker import Alpaca, OrderPreview, preview_order, reconcile_orders
+from .notifications import email_report, send_email, send_sms, send_webhook
+
+__all__ = [
+    "Alpaca",
+    "OrderPreview",
+    "preview_order",
+    "email_report",
+    "send_email",
+    "send_sms",
+    "send_webhook",
+]
+
+__all__ += ["reconcile_orders"]

--- a/src/finance/integrations/broker.py
+++ b/src/finance/integrations/broker.py
@@ -1,0 +1,163 @@
+"""Explicit brokerage operations. No orders are placed by strategies or imports."""
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class OrderPreview:
+    symbol: str
+    quantity: float
+    side: str
+    reference_price: float
+    estimated_notional: float
+    client_order_id: str
+
+
+def preview_order(
+    symbol: str,
+    quantity: float,
+    side: str,
+    price: float,
+    *,
+    maximum_notional: float,
+    client_order_id: str,
+) -> OrderPreview:
+    if not re.fullmatch(r"[A-Z][A-Z0-9./-]{0,20}", symbol) or side not in ("buy", "sell"):
+        raise ValueError("valid symbol and buy/sell side required")
+    if not all(math.isfinite(x) and x > 0 for x in (quantity, price, maximum_notional)):
+        raise ValueError("positive finite quantity, price and notional limit required")
+    if not re.fullmatch(r"[\w-]{1,48}", client_order_id):
+        raise ValueError("provide a stable 1–48 character client_order_id for this intended order")
+    notional = quantity * price
+    if notional > maximum_notional:
+        raise ValueError("order exceeds maximum_notional")
+    return OrderPreview(symbol, quantity, side, price, notional, client_order_id)
+
+
+@dataclass(frozen=True)
+class Alpaca:
+    api_key: str = field(repr=False)
+    secret_key: str = field(repr=False)
+    paper: bool = True
+    timeout: float = 20
+
+    def _request(self, method: str, path: str, payload: dict | None = None):
+        if not self.api_key or not self.secret_key or self.timeout <= 0:
+            raise ValueError("Alpaca credentials and positive timeout required")
+        host = "https://paper-api.alpaca.markets" if self.paper else "https://api.alpaca.markets"
+        request = Request(
+            host + path,
+            method=method,
+            data=json.dumps(payload).encode() if payload else None,
+            headers={
+                "APCA-API-KEY-ID": self.api_key,
+                "APCA-API-SECRET-KEY": self.secret_key,
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                body = response.read()
+            return json.loads(body) if body else None
+        except (HTTPError, URLError, TimeoutError, ValueError) as exc:
+            # A timeout after submitting can mean accepted: look up the same client ID before retrying.
+            raise RuntimeError(
+                f"Alpaca {method} {path} failed ({type(exc).__name__}); reconcile order state before resubmitting"
+            ) from exc
+
+    def account(self) -> dict:
+        return self._request("GET", "/v2/account")
+
+    def positions(self) -> list[dict]:
+        return self._request("GET", "/v2/positions")
+
+    def orders(self) -> list[dict]:
+        return self._request("GET", "/v2/orders?status=all&limit=100")
+
+    def order_by_client_id(self, client_order_id: str) -> dict:
+        return self._request(
+            "GET",
+            "/v2/orders:by_client_order_id?client_order_id=" + quote(client_order_id, safe=""),
+        )
+
+    def submit(self, order: OrderPreview, *, limit_price: float, allow_live: bool = False) -> dict:
+        """Day limit order with a stable ID; caller reconciles fills/cancellations using broker state."""
+        if not self.paper and not allow_live:
+            raise ValueError("live execution requires allow_live=True")
+        preview_order(
+            order.symbol,
+            order.quantity,
+            order.side,
+            order.reference_price,
+            maximum_notional=order.estimated_notional,
+            client_order_id=order.client_order_id,
+        )
+        if not float(order.quantity).is_integer():
+            raise ValueError("this stock limit-order adapter requires whole shares")
+        if not math.isfinite(limit_price) or limit_price <= 0:
+            raise ValueError("positive finite limit_price required")
+        if order.quantity * limit_price > order.estimated_notional * (1 + 1e-12):
+            raise ValueError(
+                "limit notional exceeds preview; generate a fresh preview at this limit"
+            )
+        return self._request(
+            "POST",
+            "/v2/orders",
+            {
+                "symbol": order.symbol,
+                "qty": str(order.quantity),
+                "side": order.side,
+                "type": "limit",
+                "time_in_force": "day",
+                "limit_price": str(limit_price),
+                "client_order_id": order.client_order_id,
+            },
+        )
+
+    def cancel(self, order_id: str, *, allow_live: bool = False) -> None:
+        if not self.paper and not allow_live:
+            raise ValueError("live cancellation requires allow_live=True")
+        self._request("DELETE", "/v2/orders/" + quote(order_id, safe=""))
+
+
+def reconcile_orders(previews: list[OrderPreview], broker_orders: list[dict]):
+    """Match intended IDs to broker state; unmatched intents are unknown, never assumed unfilled."""
+    import pandas as pd
+
+    keys = [p.client_order_id for p in previews]
+    if len(keys) != len(set(keys)):
+        raise ValueError("intended client IDs must be unique")
+    known = {}
+    for order in broker_orders:
+        if "client_order_id" not in order or "status" not in order:
+            raise ValueError("broker orders require client_order_id and status")
+        key = order["client_order_id"]
+        if key in known:
+            raise ValueError("duplicate broker client ID")
+        known[key] = order
+    rows = []
+    for preview in previews:
+        order = known.get(preview.client_order_id)
+        filled = float(order.get("filled_qty", 0)) if order else 0.0
+        if not math.isfinite(filled) or filled < 0 or filled > preview.quantity + 1e-10:
+            raise ValueError("invalid filled quantity")
+        rows.append(
+            {
+                "client_order_id": preview.client_order_id,
+                "symbol": preview.symbol,
+                "status": order["status"] if order else "unknown",
+                "quantity": preview.quantity,
+                "filled_quantity": filled,
+                "remaining_quantity": preview.quantity - filled,
+                "average_fill_price": float(order["filled_avg_price"])
+                if order and order.get("filled_avg_price")
+                else None,
+            }
+        )
+    return pd.DataFrame(rows)

--- a/src/finance/integrations/notifications.py
+++ b/src/finance/integrations/notifications.py
@@ -1,0 +1,64 @@
+import base64
+import json
+import smtplib
+import ssl
+from email.message import EmailMessage
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+def email_report(sender: str, recipient: str, subject: str, body: str) -> EmailMessage:
+    """Construct a previewable message; does not send."""
+    message = EmailMessage()
+    message["From"], message["To"], message["Subject"] = sender, recipient, subject
+    message.set_content(body)
+    return message
+
+
+def send_email(
+    message: EmailMessage,
+    host: str,
+    *,
+    port: int = 465,
+    username: str,
+    password: str,
+    timeout: float = 20,
+) -> None:
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    with smtplib.SMTP_SSL(
+        host, port, timeout=timeout, context=ssl.create_default_context()
+    ) as smtp:
+        smtp.login(username, password)
+        smtp.send_message(message)
+
+
+def send_webhook(url: str, payload: dict, *, event_id: str, timeout: float = 20) -> int:
+    """One delivery attempt; stable event ID lets a cooperating receiver deduplicate retries."""
+    if not url.startswith("https://") or not event_id or timeout <= 0:
+        raise ValueError("HTTPS URL, event_id and positive timeout required")
+    request = Request(
+        url,
+        data=json.dumps(payload, allow_nan=False).encode(),
+        headers={"Content-Type": "application/json", "Idempotency-Key": event_id},
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return response.status
+
+
+def send_sms(
+    body: str, recipient: str, sender: str, *, account_sid: str, token: str, timeout: float = 20
+) -> str:
+    """Explicit Twilio delivery; account credentials and a provisioned sender are required."""
+    import re
+
+    if not re.fullmatch(r"AC[a-fA-F0-9]{32}", account_sid) or not body or timeout <= 0:
+        raise ValueError("valid account SID, message and positive timeout required")
+    credentials = base64.b64encode(f"{account_sid}:{token}".encode()).decode()
+    request = Request(
+        f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Messages.json",
+        data=urlencode({"To": recipient, "From": sender, "Body": body}).encode(),
+        headers={"Authorization": "Basic " + credentials},
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return json.load(response)["sid"]

--- a/src/finance/models/__init__.py
+++ b/src/finance/models/__init__.py
@@ -1,9 +1,21 @@
+from .experiments import evaluate_prophet, evaluate_sequence
 from .forecasting import (
     ForecastEvaluation,
     evaluate_arima,
     evaluate_direction,
     evaluate_forecast,
     forecast_features,
+    forecast_latest,
+)
+from .research import (
+    FactorResult,
+    arima_diagnostics,
+    arima_forecast,
+    factor_analysis,
+    partial_correlations_cv,
+    select_arima_order,
+    student_t_fit,
+    volatility_regimes,
 )
 from .structure import (
     PCAResult,
@@ -28,4 +40,16 @@ __all__ = [
     "partial_correlations",
     "anomaly_scores",
     "cointegration_pairs",
+    "forecast_latest",
+    "FactorResult",
+    "factor_analysis",
+    "student_t_fit",
+    "volatility_regimes",
+    "partial_correlations_cv",
+    "arima_forecast",
+    "arima_diagnostics",
+    "evaluate_sequence",
+    "evaluate_prophet",
 ]
+
+__all__ += ["select_arima_order"]

--- a/src/finance/models/experiments.py
+++ b/src/finance/models/experiments.py
@@ -1,0 +1,118 @@
+"""Optional forecasting experiments; held-out accuracy is reported against simple baselines."""
+
+import numpy as np
+import pandas as pd
+
+from finance._validation import series, window_size
+from finance.models.forecasting import ForecastEvaluation, _scores
+
+
+def evaluate_sequence(
+    close: pd.Series,
+    *,
+    architecture: str = "lstm",
+    lookback: int = 20,
+    train_fraction: float = 0.75,
+    epochs: int = 20,
+    seed: int = 0,
+) -> ForecastEvaluation:
+    """One-step return prediction with a small LSTM or causal-window CNN; CPU, fixed epoch budget."""
+    import torch
+    from torch import nn
+
+    close = series(close, positive=True, missing=False)
+    window_size(lookback, 3)
+    window_size(epochs)
+    if architecture not in ("lstm", "cnn") or not 0.2 < train_fraction < 0.9:
+        raise ValueError("architecture lstm/cnn and chronological split in (.2,.9) required")
+    changes = close.pct_change(fill_method=None).dropna()
+    x = np.array([changes.iloc[i - lookback : i].to_numpy() for i in range(lookback, len(changes))])
+    y = changes.iloc[lookback:].to_numpy()
+    split = int(len(y) * train_fraction)
+    if split < 40 or len(y) - split < 10:
+        raise ValueError("insufficient sequence history")
+    # Scaling is fitted on training inputs only. The target uses the same return scale.
+    mean, scale = x[:split].mean(), x[:split].std()
+    if scale == 0:
+        raise ValueError("training returns are constant")
+    x = torch.tensor((x - mean) / scale, dtype=torch.float32).unsqueeze(-1)
+    labels = torch.tensor((y - mean) / scale, dtype=torch.float32).unsqueeze(-1)
+    # Preserve the caller's random generator state; no global seed changes escape this scope.
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(seed)
+        if architecture == "lstm":
+
+            class LSTM(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.sequence = nn.LSTM(1, 8, batch_first=True)
+                    self.output = nn.Linear(8, 1)
+
+                def forward(self, values):
+                    sequence, _ = self.sequence(values)
+                    return self.output(sequence[:, -1])
+
+            model = LSTM()
+        else:
+
+            class CNN(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.network = nn.Sequential(
+                        nn.Conv1d(1, 8, 3),
+                        nn.ReLU(),
+                        nn.Flatten(),
+                        nn.Linear(8 * (lookback - 2), 1),
+                    )
+
+                def forward(self, values):
+                    return self.network(values.transpose(1, 2))
+
+            model = CNN()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.005)
+        for _ in range(epochs):
+            model.train()
+            optimizer.zero_grad()
+            loss = nn.functional.mse_loss(model(x[:split]), labels[:split])
+            if not torch.isfinite(loss):
+                raise ValueError("neural training diverged")
+            loss.backward()
+            optimizer.step()
+        model.eval()
+        with torch.no_grad():
+            predicted = model(x[split:]).numpy().ravel() * scale + mean
+    index = changes.index[lookback:]
+    predictions = pd.DataFrame(
+        {"actual": y[split:], architecture: predicted, "zero_return": 0.0}, index=index[split:]
+    )
+    return ForecastEvaluation(predictions, _scores(predictions), index[split - 1], index[split])
+
+
+def evaluate_prophet(close: pd.Series, train_fraction: float = 0.8) -> ForecastEvaluation:
+    """Fixed-origin log-price forecast on observed held-out dates, compared with persistence."""
+    from prophet import Prophet
+
+    close = series(close, positive=True, missing=False)
+    if not isinstance(close.index, pd.DatetimeIndex) or not 0.2 < train_fraction < 0.9:
+        raise ValueError("dated observations and chronological split required")
+    split = int(len(close) * train_fraction)
+    train, test = close.iloc[:split], close.iloc[split:]
+    if len(train) < 60 or len(test) < 10:
+        raise ValueError("insufficient history")
+    model = Prophet(
+        daily_seasonality=False,
+        weekly_seasonality=False,
+        yearly_seasonality=False,
+        uncertainty_samples=0,
+    )
+    model.fit(pd.DataFrame({"ds": train.index.tz_localize(None), "y": np.log(train.to_numpy())}))
+    prediction = model.predict(pd.DataFrame({"ds": test.index.tz_localize(None)}))
+    result = pd.DataFrame(
+        {
+            "actual": test,
+            "prophet": np.exp(prediction.yhat.to_numpy()),
+            "persistence": train.iloc[-1],
+        },
+        index=test.index,
+    )
+    return ForecastEvaluation(result, _scores(result), train.index[-1], test.index[0])

--- a/src/finance/models/forecasting.py
+++ b/src/finance/models/forecasting.py
@@ -49,13 +49,6 @@ def evaluate_forecast(
     seed: int = 0,
 ) -> ForecastEvaluation:
     """Fixed-model chronological holdout with purged labels and a zero-return baseline."""
-    from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
-    from sklearn.linear_model import Ridge
-    from sklearn.neural_network import MLPRegressor
-    from sklearn.pipeline import make_pipeline
-    from sklearn.preprocessing import StandardScaler
-    from sklearn.svm import SVR
-
     if not 0.2 < train_fraction < 0.95:
         raise ValueError("train_fraction must be between .2 and .95")
     features, target = forecast_features(close, horizon=horizon)
@@ -64,22 +57,7 @@ def evaluate_forecast(
     train, test = data.iloc[: split - horizon], data.iloc[split:]
     if len(train) < 40 or len(test) < 10:
         raise ValueError("insufficient history after warmup, purging and chronological split")
-    estimators = {
-        "ridge": Ridge(alpha=1),
-        "forest": RandomForestRegressor(
-            n_estimators=100, max_depth=4, min_samples_leaf=10, random_state=seed
-        ),
-        "boosting": HistGradientBoostingRegressor(
-            max_iter=100, max_leaf_nodes=7, early_stopping=False, random_state=seed
-        ),
-        "svr": SVR(C=0.1),
-        "mlp": MLPRegressor(
-            hidden_layer_sizes=(16,), max_iter=1000, shuffle=False, random_state=seed
-        ),
-    }
-    if model not in estimators:
-        raise ValueError(f"model must be one of {list(estimators)}")
-    pipeline = make_pipeline(StandardScaler(), estimators[model])
+    pipeline = _forecast_pipeline(model, seed)
     columns = features.columns
     pipeline.fit(train[columns], train.target)
     predictions = pd.DataFrame(
@@ -151,3 +129,53 @@ def evaluate_direction(close: pd.Series, train_fraction: float = 0.75) -> Foreca
         }
     ).T
     return ForecastEvaluation(predictions, metrics, train.index[-1], test.index[0])
+
+
+def _forecast_pipeline(model: str, seed: int):
+    from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
+    from sklearn.linear_model import Ridge
+    from sklearn.neural_network import MLPRegressor
+    from sklearn.pipeline import make_pipeline
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.svm import SVR
+
+    estimators = {
+        "ridge": Ridge(alpha=1),
+        "forest": RandomForestRegressor(
+            n_estimators=100, max_depth=4, min_samples_leaf=10, random_state=seed
+        ),
+        "boosting": HistGradientBoostingRegressor(
+            max_iter=100, max_leaf_nodes=7, early_stopping=False, random_state=seed
+        ),
+        "svr": SVR(C=0.1),
+        "mlp": MLPRegressor(
+            hidden_layer_sizes=(16,), max_iter=1000, shuffle=False, random_state=seed
+        ),
+    }
+    if model not in estimators:
+        raise ValueError(f"model must be one of {list(estimators)}")
+    return make_pipeline(StandardScaler(), estimators[model])
+
+
+def forecast_latest(
+    close: pd.Series, *, horizon: int = 1, model: str = "ridge", seed: int = 0
+) -> pd.Series:
+    """Fit known labels and predict the next horizon return at the latest close; evaluate separately."""
+    features, target = forecast_features(close, horizon=horizon)
+    training = features.join(target).dropna()
+    if len(training) < 40 or features.iloc[-1].isna().any():
+        raise ValueError("insufficient complete history")
+    pipeline = _forecast_pipeline(model, seed)
+    pipeline.fit(training[features.columns], training.target)
+    prediction = float(pipeline.predict(features.iloc[[-1]])[0])
+    return pd.Series(
+        {
+            "as_of": close.index[-1],
+            "horizon_bars": horizon,
+            "predicted_return": prediction,
+            "implied_price": close.iloc[-1] * (1 + prediction),
+            "baseline_return": 0.0,
+            "training_end": training.index[-1],
+            "model": model,
+        }
+    )

--- a/src/finance/models/forecasting.py
+++ b/src/finance/models/forecasting.py
@@ -168,6 +168,8 @@ def forecast_latest(
     pipeline = _forecast_pipeline(model, seed)
     pipeline.fit(training[features.columns], training.target)
     prediction = float(pipeline.predict(features.iloc[[-1]])[0])
+    if not np.isfinite(prediction) or prediction <= -1:
+        raise ValueError("model predicted a nonfinite return or a nonpositive implied price")
     return pd.Series(
         {
             "as_of": close.index[-1],

--- a/src/finance/models/research.py
+++ b/src/finance/models/research.py
@@ -1,0 +1,246 @@
+"""Statistical diagnostics and chronological regime inference."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from finance._validation import frame, series, window_size
+
+
+@dataclass(frozen=True)
+class FactorResult:
+    loadings: pd.DataFrame
+    communalities: pd.Series
+    diagnostics: pd.Series
+
+
+def factor_analysis(returns: pd.DataFrame, factors: int = 2) -> FactorResult:
+    """Maximum-likelihood factor analysis of standardized observations; unrotated loadings."""
+    from scipy.stats import chi2
+    from sklearn.decomposition import FactorAnalysis
+    from sklearn.preprocessing import StandardScaler
+
+    returns = frame(returns)
+    window_size(factors)
+    n, p = returns.shape
+    if not 1 <= factors < p or n <= p + 2 or (returns.std() == 0).any():
+        raise ValueError(
+            "require fewer factors than nonconstant assets and more observations than assets"
+        )
+    correlation = returns.corr().to_numpy(copy=True)
+    sign, logdet = np.linalg.slogdet(correlation)
+    if sign <= 0 or np.linalg.cond(correlation) > 1e10:
+        raise ValueError("factor diagnostics require nonsingular correlation")
+    inverse = np.linalg.inv(correlation)
+    partial = -inverse / np.sqrt(np.outer(np.diag(inverse), np.diag(inverse)))
+    np.fill_diagonal(partial, 0)
+    np.fill_diagonal(correlation, 0)
+    numerator = (correlation**2).sum()
+    kmo = numerator / (numerator + (partial**2).sum()) if numerator else np.nan
+    statistic = -(n - 1 - (2 * p + 5) / 6) * logdet
+    scaled = StandardScaler().fit_transform(returns)
+    model = FactorAnalysis(n_components=factors, random_state=0, max_iter=2000).fit(scaled)
+    if model.n_iter_ >= 2000:
+        raise ValueError("factor analysis did not converge")
+    loadings = pd.DataFrame(
+        model.components_.T,
+        index=returns.columns,
+        columns=[f"factor_{i + 1}" for i in range(factors)],
+    )
+    return FactorResult(
+        loadings,
+        (loadings**2).sum(axis=1).rename("communality"),
+        pd.Series(
+            {
+                "kmo": kmo,
+                "bartlett_statistic": statistic,
+                "bartlett_p_value": chi2.sf(statistic, p * (p - 1) / 2),
+            }
+        ),
+    )
+
+
+def student_t_fit(values: pd.Series) -> pd.Series:
+    """MLE location/scale/df; scale is not standard deviation. Descriptive fit only."""
+    from scipy.stats import t
+
+    values = series(values, missing=False)
+    if len(values) < 30 or values.std() == 0:
+        raise ValueError("at least 30 nonconstant observations required")
+    degrees, location, scale = t.fit(values.to_numpy())
+    return pd.Series(
+        {
+            "df": degrees,
+            "location": location,
+            "scale": scale,
+            "std": scale * np.sqrt(degrees / (degrees - 2)) if degrees > 2 else np.inf,
+            "q01": t.ppf(0.01, degrees, loc=location, scale=scale),
+            "q99": t.ppf(0.99, degrees, loc=location, scale=scale),
+        }
+    )
+
+
+def volatility_regimes(
+    close: pd.Series,
+    *,
+    train_fraction: float = 0.7,
+    regimes: int = 2,
+    window: int = 20,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Mixture fitted to past rolling volatility; held-out rows contain causal state probabilities."""
+    from sklearn.mixture import GaussianMixture
+
+    close = series(close, positive=True, missing=False)
+    window_size(window, 2)
+    window_size(regimes, 2)
+    if not 0.2 < train_fraction < 0.9:
+        raise ValueError("invalid chronological split")
+    volatility = close.pct_change(fill_method=None).rolling(window).std().dropna()
+    if (volatility <= 0).any():
+        raise ValueError("positive rolling volatility required")
+    split = int(len(volatility) * train_fraction)
+    train, test = volatility.iloc[:split], volatility.iloc[split:]
+    if len(train) < max(40, regimes * 10) or len(test) < 10:
+        raise ValueError("insufficient training/test observations")
+    model = GaussianMixture(n_components=regimes, random_state=seed, n_init=5).fit(
+        np.log(train).to_numpy()[:, None]
+    )
+    if not model.converged_:
+        raise ValueError("volatility mixture did not converge")
+    order = np.argsort(model.means_[:, 0])
+    probabilities = model.predict_proba(np.log(test).to_numpy()[:, None])[:, order]
+    result = pd.DataFrame(
+        probabilities, index=test.index, columns=[f"regime_{i + 1}" for i in range(regimes)]
+    )
+    result["volatility"] = test
+    result["regime"] = probabilities.argmax(axis=1) + 1
+    result.attrs.update(training_end=train.index[-1], ordering="ascending training log-volatility")
+    return result
+
+
+def partial_correlations_cv(returns: pd.DataFrame, folds: int = 5) -> pd.DataFrame:
+    """Descriptive conditional-dependence network with chronological alpha selection."""
+    from sklearn.covariance import GraphicalLassoCV
+    from sklearn.model_selection import TimeSeriesSplit
+    from sklearn.preprocessing import StandardScaler
+
+    returns = frame(returns)
+    window_size(folds, 2)
+    if len(returns) < folds * 10 or (returns.std() == 0).any():
+        raise ValueError("insufficient nonconstant observations")
+    # Common scale uses the initial fold only; later validation observations do not fit it.
+    cv = TimeSeriesSplit(n_splits=folds)
+    first_train, _ = next(cv.split(returns))
+    scaler = StandardScaler().fit(returns.iloc[first_train])
+    fitted = GraphicalLassoCV(cv=cv, max_iter=500).fit(scaler.transform(returns))
+    if fitted.n_iter_ >= 500:
+        raise ValueError("graphical lasso did not converge")
+    precision = fitted.precision_
+    result = -precision / np.sqrt(np.outer(np.diag(precision), np.diag(precision)))
+    np.fill_diagonal(result, 1)
+    output = pd.DataFrame(result, index=returns.columns, columns=returns.columns)
+    output.attrs["alpha"] = fitted.alpha_
+    return output
+
+
+def arima_forecast(
+    close: pd.Series,
+    steps: int = 10,
+    *,
+    order: tuple[int, int, int] = (1, 1, 0),
+    confidence: float = 0.95,
+) -> pd.DataFrame:
+    """Future observation steps, not guessed exchange dates; model-based price intervals."""
+    from statsmodels.tsa.arima.model import ARIMA
+
+    close = series(close, positive=True, missing=False)
+    window_size(steps)
+    if (
+        len(close) < 40
+        or not 0 < confidence < 1
+        or len(order) != 3
+        or any(not isinstance(x, int) or x < 0 for x in order)
+    ):
+        raise ValueError("invalid history, confidence or ARIMA order")
+    model = ARIMA(close.to_numpy(), order=order).fit()
+    if not model.mle_retvals.get("converged", True):
+        raise ValueError("ARIMA failed to converge")
+    forecast = model.get_forecast(steps)
+    intervals = forecast.conf_int(alpha=1 - confidence)
+    result = pd.DataFrame(
+        {"forecast": forecast.predicted_mean, "lower": intervals[:, 0], "upper": intervals[:, 1]},
+        index=pd.RangeIndex(1, steps + 1, name="step"),
+    )
+    result.attrs.update(as_of=close.index[-1], confidence=confidence, order=order)
+    return result
+
+
+def arima_diagnostics(
+    close: pd.Series, *, order: tuple[int, int, int] = (1, 1, 0), seasonal_period: int = 21
+) -> tuple[pd.Series, pd.DataFrame]:
+    """ADF, residual Ljung–Box, and retrospective STL decomposition; not forecast features."""
+    from statsmodels.stats.diagnostic import acorr_ljungbox
+    from statsmodels.tsa.arima.model import ARIMA
+    from statsmodels.tsa.seasonal import STL
+    from statsmodels.tsa.stattools import adfuller
+
+    close = series(close, positive=True, missing=False)
+    window_size(seasonal_period, 2)
+    if len(close) < max(60, 2 * seasonal_period) or close.std() == 0:
+        raise ValueError("insufficient nonconstant history")
+    model = ARIMA(close.to_numpy(), order=order).fit()
+    if not model.mle_retvals.get("converged", True):
+        raise ValueError("ARIMA failed to converge")
+    residuals = model.resid[max(order[1], 1) :]
+    lb = acorr_ljungbox(residuals, lags=[10], return_df=True)
+    stl = STL(close, period=seasonal_period, robust=True).fit()
+    diagnostics = pd.Series(
+        {
+            "adf_price_p_value": adfuller(close)[1],
+            "adf_difference_p_value": adfuller(close.diff().dropna())[1],
+            "residual_ljung_box_p_value": lb.lb_pvalue.iloc[0],
+            "aic": model.aic,
+            "bic": model.bic,
+        }
+    )
+    return diagnostics, pd.DataFrame(
+        {"trend": stl.trend, "seasonal": stl.seasonal, "residual": stl.resid}, index=close.index
+    )
+
+
+def select_arima_order(
+    close: pd.Series,
+    orders: tuple[tuple[int, int, int], ...] = ((0, 1, 0), (1, 1, 0), (0, 1, 1)),
+    *,
+    train_fraction: float = 0.8,
+) -> pd.DataFrame:
+    """Rank candidate orders by training BIC. Failures remain visible; holdout is never fitted."""
+    from statsmodels.tsa.arima.model import ARIMA
+
+    close = series(close, positive=True, missing=False)
+    if not orders or not 0.2 < train_fraction < 0.9:
+        raise ValueError("orders and chronological split required")
+    training = close.iloc[: int(len(close) * train_fraction)]
+    if len(training) < 40:
+        raise ValueError("insufficient training history")
+    rows = []
+    for order in orders:
+        if len(order) != 3 or any(not isinstance(x, int) or x < 0 for x in order):
+            raise ValueError("each order must contain three nonnegative integers")
+        try:
+            fitted = ARIMA(training.to_numpy(), order=order).fit()
+            converged = fitted.mle_retvals.get("converged", True)
+            rows.append(
+                {
+                    "order": order,
+                    "bic": fitted.bic if converged else np.nan,
+                    "status": "converged" if converged else "not converged",
+                }
+            )
+        except (ValueError, np.linalg.LinAlgError) as exc:
+            rows.append({"order": order, "bic": np.nan, "status": str(exc)})
+    result = pd.DataFrame(rows).sort_values("bic", ignore_index=True)
+    result.attrs["training_end"] = training.index[-1]
+    return result

--- a/src/finance/reports/__init__.py
+++ b/src/finance/reports/__init__.py
@@ -1,0 +1,11 @@
+from .charts import candles, correlation_heatmap, equity_chart
+from .export import export_table, network_gexf, research_report
+
+__all__ = [
+    "candles",
+    "correlation_heatmap",
+    "equity_chart",
+    "export_table",
+    "network_gexf",
+    "research_report",
+]

--- a/src/finance/reports/charts.py
+++ b/src/finance/reports/charts.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+from finance.data import normalize_ohlcv
+
+
+def candles(prices: pd.DataFrame, overlays: pd.DataFrame | None = None):
+    """Return a matplotlib figure; no display or file writes on calculation."""
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+
+    prices = normalize_ohlcv(prices)
+    if overlays is not None and not overlays.index.equals(prices.index):
+        raise ValueError("overlays must align with prices")
+    fig, ax = plt.subplots(figsize=(11, 5))
+    for i, row in enumerate(prices.itertuples()):
+        color = "#16806a" if row.close >= row.open else "#c44848"
+        ax.vlines(i, row.low, row.high, color=color, linewidth=1)
+        height = abs(row.close - row.open)
+        ax.add_patch(
+            Rectangle(
+                (i - 0.3, min(row.open, row.close)), 0.6, height or row.close * 0.00001, color=color
+            )
+        )
+    if overlays is not None:
+        for column in overlays:
+            ax.plot(range(len(prices)), overlays[column], label=column, linewidth=1)
+        ax.legend()
+    ticks = np.linspace(0, len(prices) - 1, min(6, len(prices)), dtype=int)
+    ax.set_xticks(ticks, prices.index[ticks].strftime("%Y-%m-%d"))
+    ax.set_ylabel("Price")
+    ax.autoscale_view()
+    fig.tight_layout()
+    return fig
+
+
+def correlation_heatmap(correlation: pd.DataFrame):
+    import matplotlib.pyplot as plt
+
+    if (
+        not correlation.index.equals(pd.Index(correlation.columns))
+        or not np.isfinite(correlation).all().all()
+    ):
+        raise ValueError("finite square matrix with matching labels required")
+    fig, ax = plt.subplots(figsize=(7, 6))
+    image = ax.imshow(correlation, vmin=-1, vmax=1, cmap="RdBu_r")
+    ax.set_xticks(range(len(correlation)), correlation.columns, rotation=45, ha="right")
+    ax.set_yticks(range(len(correlation)), correlation.index)
+    fig.colorbar(image, ax=ax)
+    fig.tight_layout()
+    return fig
+
+
+def equity_chart(result):
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    result.equity.plot(ax=ax, label="Strategy")
+    result.benchmark.plot(ax=ax, label="Buy and hold")
+    ax.set_ylabel("Account value")
+    ax.legend()
+    fig.tight_layout()
+    return fig

--- a/src/finance/reports/export.py
+++ b/src/finance/reports/export.py
@@ -1,0 +1,84 @@
+from html import escape
+from pathlib import Path
+from xml.etree.ElementTree import Element, ElementTree, SubElement
+
+import numpy as np
+import pandas as pd
+
+
+def export_table(table: pd.DataFrame, path: str | Path) -> Path:
+    """CSV or optional Excel export; neutralize spreadsheet formula injection in text cells."""
+    path = Path(path)
+    safe = table.copy()
+
+    def sanitize(value):
+        if isinstance(value, pd.Timestamp) and value.tzinfo is not None:
+            return value.isoformat()
+        return (
+            "'" + value
+            if isinstance(value, str) and value.startswith(("=", "+", "-", "@", "\t", "\r"))
+            else value
+        )
+
+    safe = safe.map(sanitize)
+    safe.columns = [sanitize(c) for c in safe.columns]
+    safe.index = safe.index.map(sanitize)
+    if path.suffix.lower() == ".csv":
+        safe.to_csv(path)
+    elif path.suffix.lower() == ".xlsx":
+        safe.to_excel(path, engine="openpyxl")
+    else:
+        raise ValueError("export path must end in .csv or .xlsx")
+    return path
+
+
+def network_gexf(correlation: pd.DataFrame, path: str | Path, threshold: float = 0.2) -> Path:
+    """Undirected dependence graph with signed weights, readable by Gephi."""
+    if (
+        not correlation.index.equals(pd.Index(correlation.columns))
+        or not np.isfinite(correlation).all().all()
+    ):
+        raise ValueError("finite square labeled matrix required")
+    if not 0 <= threshold <= 1 or not np.allclose(correlation, correlation.T):
+        raise ValueError("symmetric matrix and threshold in [0,1] required")
+    root = Element("gexf", xmlns="http://www.gexf.net/1.2draft", version="1.2")
+    graph = SubElement(root, "graph", mode="static", defaultedgetype="undirected")
+    nodes, edges = SubElement(graph, "nodes"), SubElement(graph, "edges")
+    for i, ticker in enumerate(correlation):
+        SubElement(nodes, "node", id=str(i), label=str(ticker))
+    count = 0
+    for i in range(len(correlation)):
+        for j in range(i + 1, len(correlation)):
+            weight = correlation.iloc[i, j]
+            if abs(weight) >= threshold:
+                SubElement(
+                    edges, "edge", id=str(count), source=str(i), target=str(j), weight=str(weight)
+                )
+                count += 1
+    path = Path(path)
+    ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+    return path
+
+
+def research_report(
+    tables: dict[str, pd.DataFrame], path: str | Path, *, title: str = "Market research"
+) -> Path:
+    """Standalone HTML tables, with source/timestamp metadata when available."""
+    parts = [
+        '<!doctype html><meta charset="utf-8">',
+        f"<title>{escape(title)}</title>",
+        "<style>body{font:16px system-ui;max-width:1200px;margin:40px auto;padding:20px}table{border-collapse:collapse}td,th{padding:8px;border-bottom:1px solid #ddd;text-align:right}h2{margin-top:40px}</style>",
+        f"<h1>{escape(title)}</h1>",
+    ]
+    for name, table in tables.items():
+        parts.extend([f"<h2>{escape(name)}</h2>", table.to_html(escape=True)])
+        metadata = {
+            key: table.attrs[key]
+            for key in ("source", "retrieved_at", "complete", "total_matches")
+            if key in table.attrs
+        }
+        if metadata:
+            parts.append(f"<p>{escape(str(metadata))}</p>")
+    path = Path(path)
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path

--- a/src/finance/screening/__init__.py
+++ b/src/finance/screening/__init__.py
@@ -1,10 +1,13 @@
 from .screens import (
     dividend_screen,
     fundamental_screen,
+    green_line_screen,
+    growth_screen,
     ibd_relative_strength,
     minervini,
     relative_strength,
     rsi_screen,
+    rsi_trend_screen,
     technical_screen,
 )
 
@@ -16,4 +19,7 @@ __all__ = [
     "fundamental_screen",
     "dividend_screen",
     "technical_screen",
+    "growth_screen",
+    "green_line_screen",
+    "rsi_trend_screen",
 ]

--- a/src/finance/screening/screens.py
+++ b/src/finance/screening/screens.py
@@ -141,3 +141,87 @@ def technical_screen(close: pd.Series) -> pd.Series:
             "rsi": rsi(close).iloc[-1],
         }
     )
+
+
+def growth_screen(
+    companies: pd.DataFrame,
+    *,
+    growth: float = 0.1,
+    margin: float = 0.1,
+    institutional_change: float = 0,
+    maximum_pe: float = 40,
+) -> pd.DataFrame:
+    """Explain each growth/quality/ownership/value criterion; missing fields fail."""
+    required = [
+        "earnings_growth",
+        "revenue_growth",
+        "profit_margin",
+        "institutional_transactions",
+        "pe",
+    ]
+    if not set(required) <= set(companies):
+        raise ValueError(f"required columns: {required}")
+    if not np.isfinite([growth, margin, institutional_change, maximum_pe]).all() or maximum_pe <= 0:
+        raise ValueError("finite thresholds and positive maximum_pe required")
+    values = companies[required].apply(pd.to_numeric, errors="raise")
+    checks = pd.DataFrame(
+        {
+            "earnings_pass": values.earnings_growth >= growth,
+            "revenue_pass": values.revenue_growth >= growth,
+            "margin_pass": values.profit_margin >= margin,
+            "ownership_pass": values.institutional_transactions >= institutional_change,
+            "valuation_pass": values.pe.between(0, maximum_pe, inclusive="right"),
+            "complete_data": np.isfinite(values).all(axis=1),
+        }
+    )
+    return companies.join(checks).assign(passed=checks.all(axis=1))
+
+
+def green_line_screen(
+    prices: dict[str, pd.DataFrame], *, tolerance: float = 0.05, confirmations: int = 3
+) -> pd.DataFrame:
+    """Proximity to confirmed monthly record highs; exclude the current observation's month."""
+    from finance.indicators import green_line
+
+    if not prices or not 0 <= tolerance < 1:
+        raise ValueError("provide prices and tolerance in [0,1)")
+    rows = []
+    for ticker, raw in prices.items():
+        data = normalize_ohlcv(raw)
+        monthly = data.high.resample("ME").max()
+        # The final month may still be open, even when the last supplied bar is old.
+        current_month = data.index[-1].tz_localize(None).to_period("M")
+        monthly = monthly[monthly.index.tz_localize(None).to_period("M") < current_month].dropna()
+        level = green_line(monthly, confirmations).iloc[-1] if len(monthly) else np.nan
+        distance = data.close.iloc[-1] / level - 1
+        rows.append(
+            {
+                "ticker": ticker,
+                "price": data.close.iloc[-1],
+                "green_line": level,
+                "distance": distance,
+                "passed": bool(abs(distance) <= tolerance),
+            }
+        )
+    return pd.DataFrame(rows).set_index("ticker")
+
+
+def rsi_trend_screen(
+    prices: pd.DataFrame, *, rsi_window: int = 14, threshold: float = 33, average_window: int = 200
+) -> pd.DataFrame:
+    """Close above its SMA and average of the latest two RSI observations below threshold."""
+    prices = frame(prices, positive=True)
+    window_size(average_window)
+    window_size(rsi_window)
+    if not 0 <= threshold <= 100 or len(prices) < max(average_window, rsi_window + 2):
+        raise ValueError("insufficient history or invalid RSI threshold")
+    strength = prices.apply(lambda p: rsi(p, rsi_window).iloc[-2:].mean(skipna=False))
+    average = prices.rolling(average_window).mean().iloc[-1]
+    return pd.DataFrame(
+        {
+            "price": prices.iloc[-1],
+            "sma": average,
+            "rsi_two_day": strength,
+            "passed": (prices.iloc[-1] > average) & (strength < threshold),
+        }
+    )

--- a/src/finance/strategies/__init__.py
+++ b/src/finance/strategies/__init__.py
@@ -1,3 +1,12 @@
+from .research import (
+    StrategySelection,
+    ichimoku_trend,
+    keltner_breakout,
+    macd_trend,
+    select_strategy,
+    stochastic_reversion,
+    williams_reversion,
+)
 from .signals import (
     bollinger_reversion,
     breakout,
@@ -22,4 +31,11 @@ __all__ = [
     "breakout",
     "trailing_stop",
     "lag_reversal",
+    "StrategySelection",
+    "select_strategy",
+    "macd_trend",
+    "stochastic_reversion",
+    "williams_reversion",
+    "keltner_breakout",
+    "ichimoku_trend",
 ]

--- a/src/finance/strategies/research.py
+++ b/src/finance/strategies/research.py
@@ -1,0 +1,151 @@
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+import numpy as np
+import pandas as pd
+
+from finance.analytics import performance
+from finance.backtesting import BacktestResult, backtest
+from finance.data import normalize_ohlcv
+from finance.indicators import ichimoku, keltner, macd, stochastic, williams_r
+from finance.strategies.signals import crossover, threshold_reversion
+
+
+def macd_trend(
+    close: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9, *, short: bool = False
+) -> pd.Series:
+    values = macd(close, fast, slow, signal)
+    return crossover(values.macd, values.signal, short=short)
+
+
+def stochastic_reversion(
+    high: pd.Series, low: pd.Series, close: pd.Series, window: int = 14, *, short: bool = False
+) -> pd.Series:
+    values = stochastic(high, low, close, window)
+    return threshold_reversion(values.k, 20, 80, 50, short=short)
+
+
+def williams_reversion(
+    high: pd.Series, low: pd.Series, close: pd.Series, window: int = 14, *, short: bool = False
+) -> pd.Series:
+    return threshold_reversion(williams_r(high, low, close, window), -80, -20, -50, short=short)
+
+
+def keltner_breakout(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    window: int = 20,
+    multiplier: float = 2,
+    *,
+    short: bool = False,
+) -> pd.Series:
+    bands = keltner(high, low, close, window, multiplier=multiplier)
+    state, values = 0.0, []
+    for price, lower, middle, upper in zip(
+        close, bands.lower, bands.middle, bands.upper, strict=True
+    ):
+        if (state > 0 and price < middle) or (state < 0 and price > middle):
+            state = 0.0
+        elif state == 0:
+            state = 1.0 if price > upper else -1.0 if short and price < lower else 0.0
+        values.append(state)
+    return pd.Series(values, index=close.index, name="target")
+
+
+def ichimoku_trend(
+    high: pd.Series, low: pd.Series, close: pd.Series, *, short: bool = False
+) -> pd.Series:
+    values = ichimoku(high, low)
+    # Spans calculated 26 bars earlier form the cloud visible at the current bar.
+    cloud = values[["span_a", "span_b"]].shift(26)
+    above = (close > cloud.max(axis=1, skipna=False)) & (values.conversion > values.base)
+    below = (close < cloud.min(axis=1, skipna=False)) & (values.conversion < values.base)
+    return pd.Series(
+        np.select([above, below], [1.0, -1.0 if short else 0.0], 0.0),
+        index=close.index,
+        name="target",
+    )
+
+
+@dataclass(frozen=True)
+class StrategySelection:
+    training_scores: pd.DataFrame
+    selected: str
+    holdout: BacktestResult
+    training_end: object
+    test_start: object
+
+
+def select_strategy(
+    prices: pd.DataFrame,
+    candidates: dict[str, Callable],
+    *,
+    train_fraction: float = 0.7,
+    commission: float = 0.001,
+    stop_losses: tuple[float | None, ...] = (None,),
+) -> StrategySelection:
+    """Select on training total return, execute one untouched holdout; functions receive history only."""
+    prices = normalize_ohlcv(prices)
+    if not candidates or not 0.2 < train_fraction < 0.9:
+        raise ValueError("provide candidates and a split in (.2,.9)")
+    split = int(len(prices) * train_fraction)
+    if split < 60 or len(prices) - split < 20:
+        raise ValueError("insufficient train/holdout history")
+    training = prices.iloc[:split]
+    if not stop_losses or any(
+        x is not None and (not np.isfinite(x) or not 0 < x < 1) for x in stop_losses
+    ):
+        raise ValueError("stop_losses must contain None or fractions in (0,1)")
+    scores = []
+    for name, strategy in candidates.items():
+        targets = strategy(training.copy())
+        for stop in stop_losses:
+            result = backtest(
+                training.open,
+                training.close,
+                targets,
+                commission=commission,
+                liquidate=True,
+                high_prices=training.high,
+                low_prices=training.low,
+                stop_loss=stop,
+            )
+            scores.append({"candidate": name, "stop_loss": stop, **result.metrics.to_dict()})
+    table = pd.DataFrame(scores).sort_values("total_return", ascending=False, ignore_index=True)
+    selected = table.candidate.iloc[0]
+    stop_loss = table.stop_loss.iloc[0]
+    stop_loss = None if pd.isna(stop_loss) else float(stop_loss)
+    # Evaluate each decision on a prefix, so callbacks cannot inspect future bars.
+    targets = [
+        candidates[selected](prices.iloc[: i + 1].copy()).iloc[-1]
+        for i in range(split - 1, len(prices))
+    ]
+    evaluation = prices.iloc[split - 1 :]
+    result = backtest(
+        evaluation.open,
+        evaluation.close,
+        pd.Series(targets, index=evaluation.index),
+        commission=commission,
+        liquidate=True,
+        high_prices=evaluation.high,
+        low_prices=evaluation.low,
+        stop_loss=stop_loss,
+    )
+    # Drop the signal-only seed bar from holdout performance and benchmark timing.
+    equity = result.equity.iloc[1:]
+    benchmark = (10000 / prices.open.iloc[split] * prices.close.iloc[split:]).rename("benchmark")
+    metrics = performance(result.returns.iloc[1:])
+    for key in ("commissions", "borrow_costs", "fill_count"):
+        metrics[key] = result.metrics[key]
+    metrics["benchmark_return"] = benchmark.iloc[-1] / 10000 - 1
+    result = replace(
+        result,
+        equity=equity,
+        cash=result.cash.iloc[1:],
+        holdings=result.holdings.iloc[1:],
+        returns=result.returns.iloc[1:],
+        benchmark=benchmark,
+        metrics=metrics,
+    )
+    return StrategySelection(table, selected, result, training.index[-1], prices.index[split])

--- a/src/finance/strategies/research.py
+++ b/src/finance/strategies/research.py
@@ -83,9 +83,12 @@ def select_strategy(
     *,
     train_fraction: float = 0.7,
     commission: float = 0.001,
+    metric: str = "total_return",
     stop_losses: tuple[float | None, ...] = (None,),
 ) -> StrategySelection:
-    """Select on training total return, execute one untouched holdout; functions receive history only."""
+    """Rank training performance, execute one untouched holdout; callbacks receive observed history."""
+    if metric not in ("total_return", "sharpe", "sortino"):
+        raise ValueError("metric must be total_return, sharpe or sortino")
     prices = normalize_ohlcv(prices)
     if not candidates or not 0.2 < train_fraction < 0.9:
         raise ValueError("provide candidates and a split in (.2,.9)")
@@ -112,7 +115,9 @@ def select_strategy(
                 stop_loss=stop,
             )
             scores.append({"candidate": name, "stop_loss": stop, **result.metrics.to_dict()})
-    table = pd.DataFrame(scores).sort_values("total_return", ascending=False, ignore_index=True)
+    table = pd.DataFrame(scores).sort_values(metric, ascending=False, ignore_index=True)
+    if not np.isfinite(table[metric].iloc[0]):
+        raise ValueError("no candidate has a finite training score")
     selected = table.candidate.iloc[0]
     stop_loss = table.stop_loss.iloc[0]
     stop_loss = None if pd.isna(stop_loss) else float(stop_loss)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,30 @@
+"""Exercise the same UI actions users take; no network required."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+def test_stock_and_portfolio_app(ohlcv):
+    pytest.importorskip("streamlit")
+    pytest.importorskip("scipy")
+    from streamlit.testing.v1 import AppTest
+
+    app = AppTest.from_file(
+        str(Path(__file__).resolve().parents[1] / "apps/research.py"), default_timeout=30
+    ).run()
+    assert not app.exception
+    with patch("finance.data.YahooFinance.history", return_value=ohlcv):
+        app.button[0].click().run()
+    assert not app.exception and len(app.dataframe) == 3
+    app.sidebar.selectbox[0].set_value("Portfolio").run()
+    frames = [ohlcv.copy() for _ in range(4)]
+    # Different price paths avoid a singular, identical-asset optimization fixture.
+    for i, frame in enumerate(frames):
+        frame["close"] *= 1 + pd.Series(range(len(frame)), index=frame.index) * (i + 1) * 0.0001
+    with patch("finance.data.YahooFinance.history", side_effect=frames):
+        app.button[0].click().run()
+    assert not app.exception and len(app.dataframe) == 2
+    assert app.dataframe[0].value.weight.sum() == pytest.approx(1)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -155,6 +155,9 @@ def test_independent_ta_reference(ohlcv, name, reference):
         if n
         not in (
             "fibonacci_levels",
+            "gann_fan",
+            "speed_resistance",
+            "pivot_midpoints",
             "breadth",
             "green_line",
             "arms_index",

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -1,0 +1,199 @@
+import json
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+from finance.data import (
+    Finviz,
+    ProviderError,
+    TradingView,
+    article_text,
+    earnings_calendar,
+    fetch_many,
+    snapshot_changes,
+)
+from finance.data.finviz import number
+from finance.data.web import PublicWeb
+
+
+@pytest.mark.parametrize(
+    "text,expected", [("1.25B", 1.25e9), ("-2.5%", -0.025), ("$1,020", 1020), ("0", 0)]
+)
+def test_public_numbers(text, expected):
+    assert number(text) == expected
+
+
+def test_missing_number_is_not_zero():
+    assert pd.isna(number("-"))
+    with pytest.raises(ProviderError):
+        number("login required")
+
+
+def screen_page(symbols, total=21):
+    headers = [
+        "No.",
+        "Ticker",
+        "Company",
+        "Sector",
+        "Industry",
+        "Country",
+        "Market Cap",
+        "P/E",
+        "Price",
+        "Change %",
+        "Volume",
+    ]
+    rows = ["<tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr>"]
+    for symbol in symbols:
+        cells = [
+            "1",
+            f'<a href="quote.ashx?t={symbol}">{symbol}</a>',
+            "Company",
+            "Tech",
+            "Software",
+            "USA",
+            "1B",
+            "10",
+            "100",
+            "1%",
+            "1000",
+        ]
+        rows.append("<tr>" + "".join(f"<td>{v}</td>" for v in cells) + "</tr>")
+    return f"<html><p>#1 / {total} Total</p><table>" + "".join(rows) + "</table></html>"
+
+
+def test_pagination_completeness_and_schema():
+    pytest.importorskip("lxml")
+
+    class Web:
+        def text(self, url):
+            return screen_page(["LAST"] if "r=21" in url else [f"A{i}" for i in range(20)])
+
+    f = Finviz(Web())
+    result = f.screen(limit=21)
+    assert len(result) == 21 and result.attrs["complete"]
+    limited = f.screen(limit=10)
+    assert len(limited) == 10 and not limited.attrs["complete"]
+
+    class Broken:
+        def text(self, url):
+            return "<html>please log in</html>"
+
+    with pytest.raises(ProviderError):
+        Finviz(Broken()).screen()
+
+
+def test_duplicate_pages_fail():
+    pytest.importorskip("lxml")
+
+    class Web:
+        def text(self, url):
+            return screen_page([f"A{i}" for i in range(20)], 40)
+
+    with pytest.raises(ProviderError, match="Duplicate"):
+        Finviz(Web()).screen(limit=40)
+
+
+def test_company_percent_amount_and_missing():
+    pytest.importorskip("lxml")
+    pairs = [
+        ("Market Cap", "1B"),
+        ("Price", "100"),
+        ("P/E", "-"),
+        ("ROE", "20%"),
+        ("EPS next Y", "5"),
+        ("EPS next Y", "10%"),
+    ]
+    body = (
+        '<table class="snapshot-table2">'
+        + "".join(f"<tr><td>{k}</td><td>{v}</td></tr>" for k, v in pairs)
+        + "</table>"
+    )
+
+    class Web:
+        def text(self, url):
+            return body
+
+    result = Finviz(Web()).company("A")
+    assert result.expected_eps == 5 and result.expected_earnings_growth == 0.1
+    assert pd.isna(result.pe)
+    assert len(result.attrs["raw_fields"]["EPS next Y"]) == 2
+
+
+def test_calendar_negative_eps():
+    class Web:
+        def json(self, url):
+            return {
+                "data": {
+                    "rows": [
+                        {
+                            "symbol": "A",
+                            "name": "A",
+                            "epsForecast": "(0.31)",
+                            "fiscalQuarterEnding": "Jun/2026",
+                        }
+                    ]
+                }
+            }
+
+    result = earnings_calendar("2026-09-04", "2026-09-05", web=Web())
+    assert result.eps_estimate.iloc[0] == -0.31
+
+
+def test_batch_errors_and_changes():
+    def fetch(ticker):
+        if ticker == "BAD":
+            raise ProviderError("unavailable")
+        return pd.Series({"price": 10})
+
+    batch = fetch_many(["A", "BAD", "A"], fetch)
+    assert list(batch.data) == ["A"] and list(batch.errors.index) == ["BAD"]
+    changes = snapshot_changes(batch.table(), pd.DataFrame({"price": [12]}, index=["A"]))
+    assert changes.iloc[0].before == 10 and changes.iloc[0].after == 12
+
+
+def test_cache_and_http_failure(monkeypatch):
+    import finance.data.web as module
+
+    calls = []
+
+    def get(*args, **kwargs):
+        calls.append(args)
+        return BytesIO(b"hello")
+
+    monkeypatch.setattr(module, "urlopen", get)
+    web = PublicWeb(interval=0)
+    assert web.text("https://example.com") == web.text("https://example.com") == "hello"
+    assert len(calls) == 1
+
+
+def test_vendor_recommendation_schema(monkeypatch):
+    import finance.data.tradingview as module
+
+    monkeypatch.setattr(
+        module,
+        "urlopen",
+        lambda *a, **k: BytesIO(
+            json.dumps({"data": [{"s": "NASDAQ:AAPL", "d": [100, 0.2, 0.4, 0]}]}).encode()
+        ),
+    )
+    result = TradingView().recommendations(["NASDAQ:AAPL"])
+    assert result.overall.iloc[0] == 0.2
+    with pytest.raises(ProviderError):
+        TradingView().recommendations(["NASDAQ:MSFT"])
+
+
+def test_transcript_body_excludes_related_cards():
+    pytest.importorskip("lxml")
+
+    class Web:
+        def text(self, url):
+            return (
+                '<article><p>Related story</p></article><div id="article-body-transcript"><p>'
+                + ("Revenue rose. " * 30)
+                + "</p></div>"
+            )
+
+    text = article_text("https://www.fool.com/example", web=Web())
+    assert "Related" not in text and "Revenue rose." in text

--- a/tests/test_research_live.py
+++ b/tests/test_research_live.py
@@ -1,0 +1,71 @@
+"""Opt-in checks against public sources; provider failures are failures, never empty successes."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from finance.analytics import company_cash_flows, sentence_sentiment
+from finance.data import (
+    Finviz,
+    TradingView,
+    YahooFinance,
+    article_text,
+    earnings_calendar,
+    rss_news,
+    transcript_index,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_live_finviz_discovery_and_company():
+    f = Finviz()
+    screen = f.screen(["cap_largeover", "fa_epsqoq_o10"], limit=40)
+    assert len(screen) == 40 and screen.index.is_unique
+    assert screen.market_cap.ge(1e10).all()
+    company = f.company("AAPL")
+    assert company.price > 0 and 0 <= company.rsi <= 100
+    assert company.market_cap > 1e11
+    assert company["low_52w"] <= company.price <= company["high_52w"]
+    assert len(f.analysts("AAPL")) > 0
+    assert len(f.insiders()) > 0
+    assert f.news("AAPL").url.str.startswith("http").all()
+
+
+def test_live_market_calendars_and_universe():
+    f = Finviz()
+    assert len(f.universe("dow")) == 30
+    result = f.market()
+    assert len(result["movers"]) > 0 and len(result["futures"]) > 0
+    earnings = earnings_calendar("2026-09-04", "2026-09-05")
+    assert len(earnings) > 0 and earnings.ticker.notna().all()
+
+
+def test_live_statements_and_fcff():
+    provider = YahooFinance()
+    income, cash = provider.statements("AAPL", "income"), provider.statements("AAPL", "cashflow")
+    result = company_cash_flows(income, cash)
+    assert result.index[-1] == income.index[-1]
+    assert result.fcff.iloc[-1] > 0 and np.isfinite(result.fcff).all()
+    period = result.index[-1]
+    tax = income.loc[period, "Tax Provision"] / income.loc[period, "Pretax Income"]
+    expected = (
+        income.loc[period, "Operating Income"] * (1 - tax)
+        + cash.loc[
+            period,
+            ["Depreciation And Amortization", "Capital Expenditure", "Change In Working Capital"],
+        ].sum()
+    )
+    assert result.fcff.iloc[-1] == pytest.approx(expected)
+
+
+def test_live_news_transcript_and_vendor_recommendations():
+    feed = rss_news("https://feeds.content.dowjones.io/public/rss/mw_topstories")
+    assert len(feed) > 0 and isinstance(feed.published.dtype, pd.DatetimeTZDtype)
+    index = transcript_index()
+    text = article_text(index.url.iloc[0])
+    assert len(text) > 1000
+    scores = sentence_sentiment(text)
+    assert scores.compound.between(-1, 1).all()
+    recommendations = TradingView().recommendations(["NASDAQ:AAPL", "NASDAQ:MSFT"])
+    assert recommendations.drop(columns="price").abs().le(1).all().all()

--- a/tests/test_research_math.py
+++ b/tests/test_research_math.py
@@ -1,0 +1,230 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from finance.analytics import company_cash_flows, company_scenarios, seasonal_entries
+from finance.backtesting import backtest, completed_trades, trade_statistics
+from finance.indicators import gann_fan, natr, speed_resistance
+from finance.screening import green_line_screen, growth_screen
+from finance.strategies import ichimoku_trend, keltner_breakout, macd_trend, select_strategy
+
+
+def bars(opening, high, low, close):
+    index = pd.date_range("2024-01-01", periods=len(opening))
+    return pd.DataFrame(
+        {"open": opening, "high": high, "low": low, "close": close, "volume": 1000},
+        index=index,
+        dtype=float,
+    )
+
+
+@pytest.mark.parametrize("short", [False, True])
+def test_gap_stop_and_no_reentry(short):
+    p = bars([100, 100, 80, 100], [101, 101, 101, 101], [99, 99, 79, 99], [100, 100, 100, 100])
+    if short:
+        p = bars([100, 100, 120, 100], [101, 101, 121, 101], [99, 99, 99, 99], [100, 100, 100, 100])
+    target = pd.Series(-1.0 if short else 1.0, index=p.index)
+    r = backtest(
+        p.open, p.close, target, high_prices=p.high, low_prices=p.low, stop_loss=0.1, commission=0
+    )
+    assert r.equity.iloc[-1] == pytest.approx(8000)
+    assert len(r.trades) == 2
+    assert r.trades.iloc[-1].phase == "stop"
+    assert r.trades.iloc[-1].price == (120 if short else 80)
+    assert r.holdings.iloc[-1, 0] == 0
+
+
+def test_ambiguous_stop_first_and_known_trailing_level():
+    p = bars([100, 100, 100], [101, 125, 101], [99, 85, 99], [100, 100, 100])
+    target = pd.Series(1.0, index=p.index)
+    r = backtest(
+        p.open,
+        p.close,
+        target,
+        high_prices=p.high,
+        low_prices=p.low,
+        stop_loss=0.1,
+        take_profit=0.2,
+        commission=0,
+    )
+    assert r.trades.iloc[-1].price == 90
+    # Same-bar high cannot retrospectively raise the stop before the low happened.
+    r = backtest(
+        p.open,
+        p.close,
+        target,
+        high_prices=p.high,
+        low_prices=p.low,
+        trailing_fraction=0.2,
+        commission=0,
+    )
+    assert r.trades.iloc[-1].date == p.index[2]
+    assert r.trades.iloc[-1].price == 100
+
+
+def test_stops_prefix_causal_and_accounting(ohlcv):
+    target = pd.Series(np.where(np.arange(len(ohlcv)) % 60 < 30, 1.0, -1.0), index=ohlcv.index)
+
+    def run(p, t):
+        return backtest(
+            p.open,
+            p.close,
+            t,
+            high_prices=p.high,
+            low_prices=p.low,
+            stop_loss=0.03,
+            take_profit=0.06,
+            trailing_fraction=0.04,
+            borrow_rate=0.02,
+        )
+
+    full, short = run(ohlcv, target), run(ohlcv.iloc[:300], target.iloc[:300])
+    pd.testing.assert_series_equal(full.equity.iloc[:300], short.equity)
+    pd.testing.assert_series_equal(
+        full.equity, (full.cash + full.holdings.iloc[:, 0] * ohlcv.close).rename("equity")
+    )
+    matched = completed_trades(full.trades)
+    realized = matched.net_pnl.sum()
+    # Liquidation provides an independent full-cash reconciliation of matched lots and borrow.
+    closed = backtest(
+        ohlcv.open, ohlcv.close, target, commission=0.001, borrow_rate=0.02, liquidate=True
+    )
+    assert completed_trades(
+        closed.trades
+    ).net_pnl.sum() - closed.metrics.borrow_costs == pytest.approx(closed.equity.iloc[-1] - 10000)
+    assert np.isfinite(realized)
+
+
+def test_fifo_partial_close_reversal_fees():
+    fills = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=4),
+            "asset": "A",
+            "quantity": [10, -4, -10, 4],
+            "price": [100, 110, 90, 80],
+            "commission": [1, 0.4, 1, 0.4],
+        }
+    )
+    matched = completed_trades(fills)
+    assert matched.quantity.tolist() == [4, 6, 4]
+    assert matched.gross_pnl.tolist() == [40, -60, 40]
+    assert matched.net_pnl.sum() == pytest.approx(17.2)
+    assert matched.commission.sum() == pytest.approx(fills.commission.sum())
+    assert trade_statistics(matched).win_rate == pytest.approx(2 / 3)
+
+
+def test_fcff_interest_tax_sign_and_perpetuity():
+    income = pd.DataFrame(
+        {"Operating Income": [100.0], "Tax Provision": [20.0], "Pretax Income": [100.0]}
+    )
+    cf = pd.DataFrame(
+        {
+            "Depreciation And Amortization": [50.0],
+            "Capital Expenditure": [-30.0],
+            "Change In Working Capital": [-2.0],
+        }
+    )
+    assert company_cash_flows(income, cf).fcff.iloc[0] == 98
+    result = company_scenarios(
+        100, {"flat": [0] * 5}, 0.1, terminal_growth=0, cash=50, debt=100, shares=10, price=100
+    )
+    assert result.value_per_share.iloc[0] == pytest.approx(95)
+    assert result.upside.iloc[0] == pytest.approx(-0.05)
+    with pytest.raises(ValueError):
+        company_cash_flows(income, cf.assign(**{"Capital Expenditure": 30}))
+
+
+def test_seasonal_dates_and_incomplete_holds():
+    close = pd.Series(np.arange(800) + 100.0, index=pd.bdate_range("2022-01-01", periods=800))
+    result = seasonal_entries(close, 1, 15, 1)
+    row = result.iloc[0]
+    assert row.entry == pd.Timestamp("2022-01-17")
+    assert row.exit == pd.Timestamp("2022-02-17")
+    assert row["return"] == pytest.approx(close.loc[row.exit] / close.loc[row.entry] - 1)
+    assert (result.exit <= close.index[-1]).all()
+
+
+def test_growth_missing_fields_and_green_line(ohlcv):
+    c = pd.DataFrame(
+        {
+            "earnings_growth": [0.2, 0.2],
+            "revenue_growth": [0.2, np.nan],
+            "profit_margin": [0.2, 0.2],
+            "institutional_transactions": [0.1, 0.1],
+            "pe": [20, 20],
+        }
+    )
+    assert growth_screen(c).passed.tolist() == [True, False]
+    result = green_line_screen({"A": ohlcv})
+    assert result.index.tolist() == ["A"]
+    assert result.passed.iloc[0] == (abs(result.distance.iloc[0]) <= 0.05)
+
+
+def test_drawings_hand_values_and_warmup(ohlcv):
+    fan = gann_fan(5, 100, 2)
+    assert fan["1"].tolist() == [100, 102, 104, 106, 108]
+    speed = speed_resistance(100, 130, 3, 6)
+    assert speed.iloc[:3].isna().all().all()
+    assert speed["1"].iloc[3] == 130
+    values = natr(ohlcv.high, ohlcv.low, ohlcv.close)
+    assert values.iloc[:13].isna().all()
+    assert (values.dropna() > 0).all()
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        lambda p: macd_trend(p.close),
+        lambda p: keltner_breakout(p.high, p.low, p.close),
+        lambda p: ichimoku_trend(p.high, p.low, p.close),
+    ],
+)
+def test_new_signals_prefix(strategy, ohlcv):
+    pd.testing.assert_series_equal(strategy(ohlcv).iloc[:200], strategy(ohlcv.iloc[:200]))
+
+
+def test_selection_holdout_cannot_change_selection(ohlcv):
+    prices = ohlcv.iloc[:120].copy()
+    candidates = {
+        "long": lambda p: pd.Series(1.0, index=p.index),
+        "flat": lambda p: pd.Series(0.0, index=p.index),
+    }
+    first = select_strategy(prices, candidates)
+    changed = prices.copy()
+    changed.loc[changed.index[84:], ["open", "high", "low", "close"]] *= 2
+    second = select_strategy(changed, candidates)
+    assert first.selected == second.selected
+    pd.testing.assert_frame_equal(first.training_scores, second.training_scores)
+    assert first.holdout.equity.index[0] == first.test_start
+    assert first.holdout.benchmark.iloc[0] == pytest.approx(
+        10000 * prices.close.iloc[84] / prices.open.iloc[84]
+    )
+
+
+def test_latest_incomplete_fcff_is_not_silently_replaced():
+    income = pd.DataFrame(
+        {
+            "Operating Income": [100.0, 100.0],
+            "Tax Provision": [20.0, 20.0],
+            "Pretax Income": [100.0, 100.0],
+        }
+    )
+    cash = pd.DataFrame(
+        {
+            "Depreciation And Amortization": [5.0, np.nan],
+            "Capital Expenditure": [-10.0, -10.0],
+            "Change In Working Capital": [0.0, 0.0],
+        }
+    )
+    with pytest.raises(ValueError, match="latest common"):
+        company_cash_flows(income, cash)
+
+
+def test_pivot_midpoints_are_between_levels(ohlcv):
+    from finance.indicators import pivot_midpoints, pivot_points
+
+    pivots = pivot_points(ohlcv.high, ohlcv.low, ohlcv.close)
+    middle = pivot_midpoints(pivots)
+    pd.testing.assert_series_equal(
+        middle.s1_pivot, ((pivots.s1 + pivots["pivot"]) / 2).rename("s1_pivot")
+    )

--- a/tests/test_research_models_reports.py
+++ b/tests/test_research_models_reports.py
@@ -144,3 +144,18 @@ def test_excel_timestamp_roundtrip(tmp_path):
     path = export_table(data, tmp_path / "prices.xlsx")
     loaded = pd.read_excel(path, index_col=0)
     assert loaded.price.iloc[0] == 100 and "+00:00" in loaded.index[0]
+
+
+def test_latest_forecast_rejects_impossible_price(ohlcv, monkeypatch):
+    import finance.models.forecasting as module
+
+    class Model:
+        def fit(self, *args):
+            return self
+
+        def predict(self, *args):
+            return [-2.0]
+
+    monkeypatch.setattr(module, "_forecast_pipeline", lambda *args: Model())
+    with pytest.raises(ValueError, match="nonpositive"):
+        forecast_latest(ohlcv.close)

--- a/tests/test_research_models_reports.py
+++ b/tests/test_research_models_reports.py
@@ -1,0 +1,146 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from finance.integrations import Alpaca, email_report, preview_order
+from finance.models import (
+    arima_forecast,
+    evaluate_prophet,
+    evaluate_sequence,
+    factor_analysis,
+    forecast_latest,
+    student_t_fit,
+    volatility_regimes,
+)
+from finance.reports import export_table, network_gexf, research_report
+
+
+def test_latest_forecast_uses_known_labels(ohlcv):
+    pytest.importorskip("sklearn")
+    result = forecast_latest(ohlcv.close, horizon=5)
+    assert result.training_end == ohlcv.index[-6]
+    assert result.as_of == ohlcv.index[-1]
+    assert np.isfinite(result.predicted_return)
+    assert result.implied_price == pytest.approx(
+        ohlcv.close.iloc[-1] * (1 + result.predicted_return)
+    )
+
+
+def test_arima_random_walk_formula(ohlcv):
+    pytest.importorskip("statsmodels")
+    result = arima_forecast(ohlcv.close, 5, order=(0, 1, 0))
+    assert np.allclose(result.forecast, ohlcv.close.iloc[-1])
+    assert (result.lower < result.forecast).all() and (result.forecast < result.upper).all()
+    assert (result.upper - result.lower).is_monotonic_increasing
+
+
+def test_factor_known_one_factor_structure():
+    pytest.importorskip("sklearn")
+    rng = np.random.default_rng(45)
+    common = rng.normal(size=2000)
+    values = pd.DataFrame(
+        {name: common + rng.normal(0, 0.3, 2000) for name in ["A", "B", "C", "D"]}
+    )
+    result = factor_analysis(values, 1)
+    assert result.communalities.between(0.85, 0.97).all()
+    assert result.diagnostics.kmo > 0.8
+    assert result.diagnostics.bartlett_p_value < 0.001
+
+
+def test_student_t_parameter_recovery():
+    pytest.importorskip("scipy")
+    rng = np.random.default_rng(23)
+    sample = pd.Series(rng.standard_t(5, 20000) * 0.02 + 0.001)
+    result = student_t_fit(sample)
+    assert 4 < result.df < 6.5
+    assert result.scale == pytest.approx(0.02, abs=0.001)
+    assert result.location == pytest.approx(0.001, abs=0.001)
+    assert result.q01 < result.location < result.q99
+
+
+def test_regime_probabilities_and_training_boundary(ohlcv):
+    pytest.importorskip("sklearn")
+    result = volatility_regimes(ohlcv.close)
+    assert np.allclose(result[["regime_1", "regime_2"]].sum(axis=1), 1)
+    assert result.attrs["training_end"] < result.index[0]
+
+
+@pytest.mark.parametrize("architecture", ["lstm", "cnn"])
+def test_neural_baseline_and_chronology(architecture, ohlcv):
+    pytest.importorskip("torch")
+    result = evaluate_sequence(ohlcv.close.iloc[:180], architecture=architecture, epochs=2)
+    assert result.training_end < result.test_start
+    assert result.predictions.zero_return.eq(0).all()
+    assert np.isfinite(result.metrics).all().all()
+
+
+def test_prophet_chronology_and_baseline(ohlcv):
+    pytest.importorskip("prophet")
+    result = evaluate_prophet(ohlcv.close.iloc[:180])
+    assert result.predictions.persistence.nunique() == 1
+    assert result.training_end < result.test_start
+    assert np.isfinite(result.metrics).all().all()
+
+
+def test_exports_escape_content(tmp_path):
+    data = pd.DataFrame(
+        {"text": ["=1+1", "<script>alert(1)</script>"], "value": [1.0, -2.0]}, index=["A", "B"]
+    )
+    path = export_table(data, tmp_path / "report.csv")
+    assert "'=1+1" in path.read_text()
+    report = research_report({"Research": data}, tmp_path / "report.html")
+    assert "<script>" not in report.read_text()
+    assert "&lt;script&gt;" in report.read_text()
+    corr = pd.DataFrame([[1, 0.5], [0.5, 1]], index=["A", "B"], columns=["A", "B"])
+    path = network_gexf(corr, tmp_path / "network.gexf")
+    from xml.etree import ElementTree
+
+    root = ElementTree.parse(path)
+    assert len(root.findall(".//{http://www.gexf.net/1.2draft}edge")) == 1
+
+
+def test_order_preview_and_live_gate(monkeypatch):
+    order = preview_order("AAPL", 2, "buy", 100, maximum_notional=250, client_order_id="signal-001")
+    assert order.estimated_notional == 200
+    with pytest.raises(ValueError):
+        preview_order("AAPL", 3, "buy", 100, maximum_notional=250, client_order_id="signal-001")
+    calls = []
+    monkeypatch.setattr(
+        Alpaca, "_request", lambda self, *args: calls.append(args) or {"id": "example"}
+    )
+    paper = Alpaca("key", "secret")
+    assert paper.submit(order, limit_price=100)["id"] == "example"
+    assert calls[0][2]["client_order_id"] == "signal-001"
+    with pytest.raises(ValueError):
+        Alpaca("key", "secret", paper=False).submit(order, limit_price=100)
+    assert "secret" not in repr(paper)
+    message = email_report("a@example.com", "b@example.com", "Preview", "Body")
+    assert message["Subject"] == "Preview" and message.get_content().strip() == "Body"
+
+
+def test_reconcile_partial_fill_and_unknown():
+    from finance.integrations import reconcile_orders
+
+    order = preview_order("AAPL", 2, "buy", 100, maximum_notional=250, client_order_id="one")
+    result = reconcile_orders(
+        [order],
+        [
+            {
+                "client_order_id": "one",
+                "status": "partially_filled",
+                "filled_qty": "1",
+                "filled_avg_price": "99",
+            }
+        ],
+    )
+    assert result.remaining_quantity.iloc[0] == 1
+    assert result.average_fill_price.iloc[0] == 99
+    assert reconcile_orders([order], []).status.iloc[0] == "unknown"
+
+
+def test_excel_timestamp_roundtrip(tmp_path):
+    pytest.importorskip("openpyxl")
+    data = pd.DataFrame({"price": [100.0]}, index=pd.date_range("2024-01-01", periods=1, tz="UTC"))
+    path = export_table(data, tmp_path / "prices.xlsx")
+    loaded = pd.read_excel(path, index_col=0)
+    assert loaded.price.iloc[0] == 100 and "+00:00" in loaded.index[0]


### PR DESCRIPTION
Expand Finance from isolated calculations into public market-discovery, company-research, strategy-evaluation and reporting workflows. Users can screen a market universe, inspect company statements and news, compare strategies on later data, and explore the results in a small optional app.

- Add account-free Finviz discovery, fundamentals, analysts, insiders and market summaries; Yahoo statements, Nasdaq earnings calendars, public feeds/transcripts and TradingView scanner snapshots. Preserve source metadata, missing values, pagination completeness and per-ticker failures.
- Add explained growth/ownership screens, Green Line and RSI/trend watchlists, statement ratios, operating-company FCFF scenarios and seasonal entry studies.
- Extend the shared backtester with long/short protective orders, conservative intrabar assumptions, FIFO completed-lot reporting and training-only strategy/stop selection.
- Add latest-observation forecasts, ARIMA diagnostics/order selection, factor diagnostics, volatility regimes, Student-t fitting and dependence networks. Keep LSTM/CNN/Prophet experiments optional and report held-out baseline comparisons.
- Add a Streamlit research app, chart/report exports, explicit notification transports, order previews and an Alpaca client. Core dependencies remain NumPy and pandas.

Validation: 170 local tests passed; 23 opt-in live checks passed separately. The core-only environment passed 130 tests. All 20 offline examples executed. Real runs covered Finviz pagination and company screens, the Dow universe, statements/valuation, earnings, news/transcripts, TradingView recommendations, strategy holdouts, model baselines and exports. Ruff and package builds pass. All CI jobs pass across Python 3.12–3.14, including a separate optional app/model job.

Provider limits are documented. Reddit rejected anonymous access with HTTP 403; anonymous X search returned an HTML shell without tweet records, so X collection is not supplied. The TradingView scanner is undocumented. Brokerage and delivery transports have offline contract checks, but account-connected execution and actual delivery remain unverified without credentials. No orders or notifications were sent.
