### PR TITLE
docs: improve contributor navigation and API contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Working in Finance
+
+Finance is a Python quantitative research toolkit. Keep code and examples approachable
+to human contributors as well as coding agents.
+
+## Start here
+
+- [README](README.md): installation and public usage.
+- [Contributing](CONTRIBUTING.md): task map, dependency profiles and verification commands.
+- [Provider contracts](docs/providers.md): data sources, units and availability limits.
+- [Research workflows](docs/workflows.md): composed examples and optional features.
+
+## Find the right boundary
+
+Public imports are exposed by each `src/finance/<area>/__init__.py`.
+`data` owns acquisition and normalization; `indicators`, `analytics`, `screening` and
+`portfolio` own calculations. `strategies` produces targets, `backtesting` executes them,
+and `models` owns statistical experiments. Presentation belongs in `reports`, `examples`
+or `apps`; external actions belong in `integrations`.
+
+Read the closest implementation, runnable example and focused test before editing.
+Prefer small functions and existing boundaries over new frameworks. Keep optional imports
+inside the features that need them; importing core modules must not fetch data or start work.
+
+## Preserve financial meaning
+
+- Check each API's units: a return of `0.05` means 5%, while RSI uses 0–100.
+- Preserve index alignment and indicator warm-up NaNs. Do not silently fill missing prices.
+- Keep all OHLC prices on the same adjustment basis. Adjusted prices already include
+  dividend effects; adding dividend cash again would double-count them.
+- Strategies use information available at the signal timestamp. The backtester applies
+  the execution delay; do not shift strategy targets a second time.
+- Current universes and company snapshots cannot establish historical availability.
+  Inspect provider completeness metadata and batch errors before using a result.
+- Evaluate forecasts chronologically, fit transformations on training data and retain a
+  simple baseline. Training fit is not evidence of predictive advantage.
+
+## Finish a change
+
+Use the relevant checks in [Contributing](CONTRIBUTING.md#verification). Numerical changes
+need a focused regression test and an independent formula, fixture or reference where
+practical. Inspect example outputs as well as exit status. Report the commands run, skipped
+coverage and any provider failures accurately. Keep documentation about current behavior;
+put API assumptions in short docstrings and usage in runnable examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,95 @@
 # Contributing
 
-Keep calculations separate from data providers. Include a focused regression test for
-changes to numerical results, signal timing or execution accounting. Prefer hand-calculated
-fixtures or independent references for financial formulas.
+Keep calculations separate from providers and presentation. Prefer small functions with
+explicit inputs and outputs. Public APIs should state non-obvious columns, index meaning,
+units, missing-data behavior and financial assumptions in short docstrings.
 
-Install the development dependencies and run the local checks:
+## Find your starting point
+
+Public imports live in each area's `__init__.py`. Paths below are relative to the repository
+root; test filenames are under `tests/` and example filenames under `examples/`.
+
+| Change | Source | Example | Focused tests |
+| --- | --- | --- | --- |
+| Provider or index universe | `src/finance/data/` | `research_watchlist.py`, `download_market_data.py` | `test_public_sources.py`, `test_provider_contracts.py` |
+| Indicator | `src/finance/indicators/` | `calculate_indicators.py` | `test_indicators.py` |
+| Returns, risk or valuation | `src/finance/analytics/` | `analyze_stock_returns.py`, `value_a_company.py` | `test_analytics.py`, `test_research_math.py` |
+| Stock screen | `src/finance/screening/` | `screen_minervini.py` | `test_data_screening.py`, `test_research_math.py` |
+| Signal or execution rule | `src/finance/strategies/`, `src/finance/backtesting/` | `backtest_moving_average.py`, `select_strategy.py` | `test_backtesting.py`, `test_research_math.py` |
+| Allocation or simulation | `src/finance/portfolio/` | `optimize_portfolio.py`, `simulate_portfolio.py` | `test_portfolio.py` |
+| Forecast or clustering | `src/finance/models/` | `forecast_time_series.py`, `research_models.py` | `test_models.py`, `test_research_models_reports.py` |
+| Report or dashboard | `src/finance/reports/`, `apps/research.py` | `research_watchlist.py` | `test_research_models_reports.py`, `test_app.py` |
+| External integration | `src/finance/integrations/` | `preview_order.py` | `test_research_models_reports.py` |
+
+For example, an indicator change starts with its public import, the calculation and the
+existing fixtures. Run `python -m pytest tests/test_indicators.py` and
+`python examples/calculate_indicators.py`; inspect alignment, warm-up values and ranges.
+For a strategy change, inspect fill timestamps and reconcile cash plus holdings with equity.
+For a provider change, use saved or synthetic responses in offline tests and inspect
+completeness, missing fields and source timestamps in an explicit live run.
+
+## Verification
+
+Run commands from the repository root with Python 3.12 or newer. Start with a fresh virtual
+environment so installed optional packages do not disguise a missing dependency:
 
 ```bash
-python -m pip install -e '.[data,portfolio,models,sentiment,plot,dev]'
-ruff check .
-ruff format --check .
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[data,portfolio,models,sentiment,plot,reports,dev]'
+export MPLBACKEND=Agg
+python -m ruff check .
+python -m ruff format --check .
 python -m pytest
 python scripts/check_examples.py
+python -m build
 ```
 
-Tests and examples use offline data by default. To check external providers explicitly:
+On Windows, use `.venv\Scripts\Activate.ps1` and `$env:MPLBACKEND = "Agg"` in PowerShell.
+The noninteractive backend also allows dashboard plots in worker threads on macOS.
+This standard setup
+covers ordinary research workflows and matches CI's full profile. Examples use synthetic
+data by default; the runner excludes the download example and uses a noninteractive plotting
+backend. It does not exercise neural/Prophet flags or launch the dashboard.
+
+To verify the small core dependency set, use a **separate fresh environment** and run:
+
+```bash
+python -m pip install . pytest
+python -m pytest
+```
+
+Optional-dependency skips are expected in this core profile. The standard profile still
+skips neural, Prophet and dashboard tests unless their packages are installed. Pytest prints
+skip reasons: a passing run establishes only the coverage actually executed, and example
+execution alone does not establish numerical correctness.
+
+For changes involving heavy models or the dashboard, add their dependencies and checks:
+
+```bash
+python -m pip install -e '.[models,neural,prophet,apps,reports,sentiment,dev]'
+export MPLBACKEND=Agg
+python -m pytest tests/test_research_models_reports.py tests/test_app.py
+python examples/research_models.py --neural --prophet
+```
+
+CI runs core and standard profiles on Python 3.12–3.14, plus heavy-model and dashboard tests
+on Python 3.12. See the [workflow](.github/workflows/ci.yml) for exact environments.
+
+### Live providers
+
+Network tests are skipped unless explicitly enabled. With the standard dependencies:
 
 ```bash
 python -m pytest --live -m integration
 python scripts/check_examples.py --live
 ```
 
-CI checks core and optional features on Python 3.12–3.14 without live provider requests.
+These contact public providers and can fail because of throttling or schema changes. They
+are separate from offline CI and do not establish ongoing availability. See
+[provider contracts](docs/providers.md) and [research workflows](docs/workflows.md) for
+source limitations and account-dependent integrations.
+
+Include focused regression coverage when changing numerical results, signal timing or
+execution accounting. Use hand-calculated fixtures or independent references where practical.
+In a PR, explain the resulting behavior, the checks run and any skipped or unverified paths.

--- a/src/finance/backtesting/engine.py
+++ b/src/finance/backtesting/engine.py
@@ -9,6 +9,12 @@ from finance.analytics import performance
 
 @dataclass(frozen=True)
 class BacktestResult:
+    """Bar-indexed equity/cash, share holdings, fractional returns and benchmark equity.
+
+    trades contains individual fills, including partial position adjustments;
+    metrics contains aggregate performance and cost statistics.
+    """
+
     equity: pd.Series
     cash: pd.Series
     holdings: pd.DataFrame
@@ -37,6 +43,11 @@ def backtest(
     trailing_fraction: float | None = None,
 ) -> BacktestResult:
     """Close signals execute next open. Gross target <=1; fractional shares, no cash interest.
+
+    Inputs are one-asset Series or timestamp-by-asset DataFrames with identical ordered
+    indices/columns and no missing values. Targets are signed equity fractions at signal
+    close; pass them unshifted. Commission/slippage are per-fill fractions; borrow_rate
+    is annualized using periods bars per year. Output holdings are share quantities.
 
     Rebalance on target changes (or every bar with rebalance=True). Trade rows are fills,
     including partial adjustments. Adjusted OHLC must share a basis. Short borrow is charged

--- a/src/finance/data/finviz.py
+++ b/src/finance/data/finviz.py
@@ -66,6 +66,8 @@ def _stamp(result, url):
 
 @dataclass
 class Finviz:
+    """Public snapshots requiring the data extra; attrs record source and retrieval time."""
+
     web: PublicWeb = field(default_factory=PublicWeb)
 
     def _get(self, path, **params):
@@ -75,7 +77,13 @@ class Finviz:
     def screen(
         self, filters: list[str] | None = None, *, order: str = "ticker", limit: int = 100
     ) -> pd.DataFrame:
-        """Provider filter codes, e.g. cap_largeover,fa_epsqoq_o10. Explicit limit; attrs show completeness."""
+        """Fetch up to limit rows using Finviz filter codes, e.g. ['cap_largeover'].
+
+        Index: source ticker. Columns: name, sector, industry, country, market_cap,
+        pe, price, change, volume. Percent change is fractional; missing numbers are NaN.
+        Inspect attrs['complete'] and attrs['total_matches'] before treating this as
+        the full result. These are current snapshots, not historical constituents.
+        """
         if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 10000:
             raise ValueError("limit must be an integer in [1,10000]")
         if any(not re.fullmatch(r"[\w.-]+", item) for item in [order, *(filters or [])]):
@@ -147,12 +155,22 @@ class Finviz:
         return _stamp(result, url)
 
     def universe(self, index: str, *, limit: int = 3000) -> pd.DataFrame:
+        """Return screen rows for sp500, dow, nasdaq100 or russell2000.
+
+        Membership follows Finviz's current classification. The index contains tickers;
+        attrs['complete'] reports whether all provider matches fit within limit.
+        """
         codes = {"sp500": "sp500", "dow": "dji", "nasdaq100": "ndx", "russell2000": "rut"}
         if index not in codes:
             raise ValueError(f"index must be one of {list(codes)}")
         return self.screen([f"idx_{codes[index]}"], limit=limit)
 
     def company(self, ticker: str) -> pd.Series:
+        """Numeric snapshot named by ticker; growth, yield and ownership are fractions.
+
+        RSI uses 0–100. Unavailable numbers are NaN; source-absent optional fields may
+        be omitted. attrs['raw_fields'] retains source labels and duplicate values.
+        """
         root, url = self._get("quote.ashx", t=ticker)
         fields = {
             "Market Cap": "market_cap",
@@ -231,6 +249,10 @@ class Finviz:
         return _stamp(output, url)
 
     def analysts(self, ticker: str) -> pd.DataFrame:
+        """Rows of date, action, analyst, rating_change and target_change.
+
+        Dates are timezone-naive; rating and target changes retain provider text.
+        """
         root, url = self._get("quote.ashx", t=ticker)
         headers, rows = _table(
             root, ["Date", "Action", "Analyst", "Rating Change", "Price Target Change"]
@@ -242,6 +264,11 @@ class Finviz:
         return _stamp(result, url)
 
     def insiders(self) -> pd.DataFrame:
+        """Recent market-wide transactions, not a complete filing history.
+
+        Columns: ticker, owner, relationship, date, transaction, price, shares, value,
+        filing. date is the transaction date; filing retains the source display text.
+        """
         root, url = self._get("insidertrading.ashx")
         headers, rows = _table(
             root, ["Ticker", "Owner", "Transaction", "Cost", "#Shares", "Value ($)"]
@@ -272,6 +299,11 @@ class Finviz:
         return _stamp(result, url)
 
     def news(self, ticker: str | None = None) -> pd.DataFrame:
+        """Company or market headlines: ticker, title, url and source_time columns.
+
+        source_time retains display text, not a normalized publication timestamp.
+        Rows are deduplicated by URL; article bodies are not included.
+        """
         root, url = self._get("quote.ashx", t=ticker) if ticker else self._get("news.ashx")
         selector = (
             '//table[@id="news-table"]//tr'

--- a/src/finance/data/normalize.py
+++ b/src/finance/data/normalize.py
@@ -13,7 +13,11 @@ def normalize_ticker(ticker: str) -> str:
 
 
 def normalize_ohlcv(raw: pd.DataFrame) -> pd.DataFrame:
-    """Validate one ticker's OHLCV. Never fill gaps or mix adjusted and raw prices."""
+    """Return float open/high/low/close/volume on a sorted, unique DatetimeIndex.
+
+    Preserve timezone and price basis; this function does not adjust prices or fill gaps.
+    Missing values, nonpositive prices, negative volume or inconsistent OHLC raise ValueError.
+    """
     if not isinstance(raw, pd.DataFrame) or raw.empty:
         raise ValueError("provider returned no price rows")
     data = raw.copy()

--- a/src/finance/data/providers.py
+++ b/src/finance/data/providers.py
@@ -48,6 +48,12 @@ class YahooFinance:
         )
 
     def history(self, ticker: str, start: str, end: str, *, interval: str = "1d") -> pd.DataFrame:
+        """Return float open/high/low/close/volume columns for [start, end).
+
+        The sorted, unique DatetimeIndex retains the provider timezone. Missing or
+        invalid OHLCV raises ProviderError. attrs['adjusted'] records the price basis;
+        the default includes split and dividend adjustments in all OHLC prices.
+        """
         if pd.Timestamp(start) >= pd.Timestamp(end):
             raise ValueError("start must precede end")
         handle = self._ticker(ticker)

--- a/src/finance/data/research.py
+++ b/src/finance/data/research.py
@@ -21,7 +21,12 @@ class BatchResult:
 
 
 def fetch_many(tickers: Iterable[str], fetch: Callable) -> BatchResult:
-    """Sequential requests respect the provider's rate limits; no silent dropped symbols."""
+    """Fetch each distinct ticker sequentially using fetch(ticker).
+
+    Successful values remain in result.data; ProviderError messages are indexed by
+    failed ticker in result.errors. Other exceptions propagate. Use result.table()
+    for company Series snapshots; price histories remain separate DataFrames in data.
+    """
     if isinstance(tickers, str):
         raise ValueError("provide a sequence of tickers")
     data, errors = {}, {}

--- a/src/finance/models/forecasting.py
+++ b/src/finance/models/forecasting.py
@@ -27,7 +27,12 @@ def _scores(predictions: pd.DataFrame) -> pd.DataFrame:
 def forecast_features(
     close: pd.Series, lags: int = 5, horizon: int = 1
 ) -> tuple[pd.DataFrame, pd.Series]:
-    """Features known at close t, target close[t+h]/close[t]-1. Keep the final unknown labels missing."""
+    """Return features known at close t and fractional target close[t+h]/close[t]-1.
+
+    Both outputs retain the input index. Warm-up features and final unknown labels stay
+    NaN. Feature RSI is scaled to 0–1; volatility is per-bar return standard deviation.
+    horizon and lags count observations, not calendar days.
+    """
     close = series(close, positive=True, missing=False)
     window_size(lags)
     window_size(horizon)
@@ -48,7 +53,13 @@ def evaluate_forecast(
     model: str = "ridge",
     seed: int = 0,
 ) -> ForecastEvaluation:
-    """Fixed-model chronological holdout with purged labels and a zero-return baseline."""
+    """Fixed-model chronological holdout with purged labels and a zero-return baseline.
+
+    Predictions are indexed by signal origin, with actual, model-named and zero_return
+    columns in fractional return units. Metrics are MAE/RMSE in those same units.
+    Scaling is fitted on training data; horizon overlapping labels are purged before
+    the holdout. Requires the models extra; a successful fit does not imply an advantage.
+    """
     if not 0.2 < train_fraction < 0.95:
         raise ValueError("train_fraction must be between .2 and .95")
     features, target = forecast_features(close, horizon=horizon)

--- a/src/finance/portfolio/allocation.py
+++ b/src/finance/portfolio/allocation.py
@@ -75,7 +75,14 @@ def optimize(
     bounds: tuple[float, float] = (0, 1),
     target_return: float | None = None,
 ) -> Allocation:
-    """Long-only SLSQP optimization, with explicit solver and constraint verification."""
+    """Find long-only weights summing to one within the shared asset bounds.
+
+    mean and both covariance axes must have the same asset labels. Use fractional
+    returns and a consistent time basis for mean, covariance, risk_free and target_return.
+    objective is minimum_variance or maximum_sharpe; target_return is an equality.
+    Return Allocation with asset-indexed weights and return/volatility/sharpe statistics.
+    Requires the portfolio extra; invalid inputs or failed constraints raise ValueError.
+    """
     from scipy.optimize import minimize
 
     mean, covariance = _inputs(mean, covariance)

--- a/src/finance/screening/screens.py
+++ b/src/finance/screening/screens.py
@@ -9,7 +9,12 @@ from finance.indicators import rsi, sma
 def relative_strength(
     prices: pd.DataFrame, benchmark: pd.Series, window: int = 252
 ) -> pd.DataFrame:
-    """Gross-return ratio and percentile rank within the supplied universe."""
+    """Rank assets by gross-return ratio against an exactly aligned benchmark.
+
+    prices has timestamp rows and asset columns, with window+1 complete positive rows.
+    Output is asset-indexed: return is fractional, relative_strength is a gross-return
+    ratio and rank is a percentile on a 0–100 scale within the supplied universe.
+    """
     prices, benchmark = (
         frame(prices, positive=True),
         series(benchmark, positive=True, missing=False),
@@ -46,7 +51,12 @@ def ibd_relative_strength(prices: pd.DataFrame) -> pd.DataFrame:
 def minervini(
     prices: dict[str, pd.DataFrame], benchmark: pd.Series, *, minimum_rank: float = 70
 ) -> pd.DataFrame:
-    """Trend-template diagnostics for every ticker; select passed rows explicitly."""
+    """Trend-template diagnostics for every ticker; select passed rows explicitly.
+
+    Supply ticker-to-OHLCV frames with at least 253 common observations and an exactly
+    aligned benchmark Series. Output is ticker-indexed, with prices, averages, relative
+    strength rank, individual Boolean checks and the combined passed column.
+    """
     if not 0 <= minimum_rank <= 100 or not prices:
         raise ValueError("provide prices and a rank threshold in [0,100]")
     normalized = {ticker: normalize_ohlcv(data) for ticker, data in prices.items()}

--- a/src/finance/strategies/research.py
+++ b/src/finance/strategies/research.py
@@ -86,7 +86,13 @@ def select_strategy(
     metric: str = "total_return",
     stop_losses: tuple[float | None, ...] = (None,),
 ) -> StrategySelection:
-    """Rank training performance, execute one untouched holdout; callbacks receive observed history."""
+    """Rank training performance, then execute the selected candidate on one holdout.
+
+    candidates maps names to callbacks taking OHLCV history and returning aligned,
+    unshifted target Series. Callbacks must be causal within their input history;
+    holdout evaluation calls them on expanding observed prefixes. training_scores
+    contains training metrics, while holdout contains the selected backtest result.
+    """
     if metric not in ("total_return", "sharpe", "sortino"):
         raise ValueError("metric must be total_return, sharpe or sortino")
     prices = normalize_ohlcv(prices)

--- a/src/finance/strategies/signals.py
+++ b/src/finance/strategies/signals.py
@@ -20,6 +20,10 @@ def moving_average(
     exponential: bool = False,
     short: bool = False,
 ) -> pd.Series:
+    """Close-time targets: 1 when fast > slow, otherwise 0 (or -1 with short=True).
+
+    Keep the close index; warm-up targets are zero. Pass targets unshifted to backtest.
+    """
     if fast >= slow:
         raise ValueError("fast must be smaller than slow")
     average = ema if exponential else sma


### PR DESCRIPTION
Contributors can now find the right implementation, example and focused checks from a single task map. A short agent orientation links to the same human-facing guidance and records the financial constraints that matter when editing the code.

Clarify public API inputs and outputs around units, index alignment, snapshot completeness, forecast labels and execution timing. Document separate core, standard, heavy-model and live verification paths, including expected skips and the noninteractive plotting backend needed by macOS dashboard tests.

Validation:
- Fresh core environment: 130 passed, 56 skipped; fresh standard environment: 166 passed, 27 skipped. Skips reflect optional dependencies and opt-in live checks.
- All 20 offline examples, package build and Ruff checks passed in the standard environment.
- Existing optional environment: 14 model/report/dashboard tests and the neural/Prophet example passed with `MPLBACKEND=Agg`.
- Public API walkthroughs checked RSI warm-up, next-open fills, cash/equity reconciliation and an independently calculated minimum-variance allocation.
- Guide links and task-map paths resolve; AST comparison confirms Python edits only change docstrings. Live providers were not rerun for this documentation change.
