### PR TITLE
fix(data): require a Finviz total on every results page

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -42,7 +42,8 @@ opt-in and excluded from CI; provider failures are reported as test failures.
 
 Finviz provides public screener, company, analyst, insider and news snapshots. Fetching uses
 bounded retries for throttling/transient server errors, per-client request spacing and a
-short in-memory cache. Pagination rejects duplicate rows and changing result counts;
+short in-memory cache. Every results page must report the same parseable total count.
+Pagination rejects duplicate rows and missing or changing result counts;
 explicit limits are reported through `complete` and `total_matches` attributes. An HTTP 200
 response without the expected table is an error, not an empty result. Percentages normalize
 to fractions; multiple measures inside a cell remain distinct. Native ticker symbols are

--- a/src/finance/data/finviz.py
+++ b/src/finance/data/finviz.py
@@ -96,11 +96,14 @@ class Finviz:
             )
             text = _text(root)
             match = re.search(r"/\s*([\d,]+)\s+Total", text)
-            if match:
-                count = int(match[1].replace(",", ""))
-                if total is not None and count != total:
-                    raise ProviderError("Screener changed during pagination; retry the snapshot")
-                total = count
+            if match is None:
+                raise ProviderError(
+                    f"Finviz total count missing at offset {offset}; completeness cannot be established"
+                )
+            count = int(match[1].replace(",", ""))
+            if total is not None and count != total:
+                raise ProviderError("Screener changed during pagination; retry the snapshot")
+            total = count
             if total == 0:
                 break
             headers, rows = _table(root, ["Ticker", "Company", "Market Cap", "Price"])
@@ -127,7 +130,7 @@ class Finviz:
             if not page:
                 raise ProviderError("Finviz returned no parseable screener rows")
             records.extend(page)
-            if total is not None and len(records) >= total:
+            if len(records) >= total:
                 break
         result = pd.DataFrame(
             records,
@@ -146,8 +149,6 @@ class Finviz:
         ).set_index("ticker")
         if result.index.has_duplicates:
             raise ProviderError("Duplicate tickers across screener pages; retry the snapshot")
-        if total is None:
-            raise ProviderError("Finviz total count missing; completeness cannot be established")
         result = result.iloc[:limit]
         result.attrs.update(
             total_matches=total, complete=len(result) == total, filters=filters or []

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -84,6 +84,41 @@ def test_pagination_completeness_and_schema():
         Finviz(Broken()).screen()
 
 
+@pytest.mark.parametrize("missing_offset", [1, 21])
+def test_pagination_requires_total_on_every_page(missing_offset):
+    pytest.importorskip("lxml")
+
+    class Web:
+        def __init__(self):
+            self.offsets = []
+
+        def text(self, url):
+            offset = 21 if "r=21" in url else 1
+            self.offsets.append(offset)
+            body = screen_page(["LAST"] if offset == 21 else [f"A{i}" for i in range(20)])
+            if offset == missing_offset:
+                return body.replace("<p>#1 / 21 Total</p>", "")
+            return body
+
+    web = Web()
+    with pytest.raises(ProviderError, match="total count missing"):
+        Finviz(web).universe("sp500", limit=21)
+    assert web.offsets == ([1] if missing_offset == 1 else [1, 21])
+
+
+def test_explicit_zero_total_is_complete():
+    pytest.importorskip("lxml")
+
+    class Web:
+        def text(self, url):
+            return screen_page([], total=0)
+
+    result = Finviz(Web()).screen()
+    assert result.empty and result.attrs["complete"]
+    assert result.attrs["total_matches"] == 0
+    assert result.index.name == "ticker" and "price" in result
+
+
 def test_duplicate_pages_fail():
     pytest.importorskip("lxml")
 


### PR DESCRIPTION
Finviz pagination could report `complete=True` when one results page omitted its total count, using a count from another page. Require a total on every fetched page and raise `ProviderError` with the offending offset before accepting its rows.

Add regression coverage for missing first-page and later-page totals, verify that an explicit zero remains a valid complete result, and clarify the provider contract.

Validation: the two missing-total cases failed before the fix. Afterward, 173 tests passed (23 opt-in live tests skipped), Ruff lint/format and diff checks passed, and the original benchmark reproduction correctly raised at offset 21. A separate live Dow workflow returned 30 unique tickers across two pages with `complete=True`; limiting it to 10 correctly returned `complete=False` with total 30.
